### PR TITLE
Fixed composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "react/promise": "~2.0"
     },
     "autoload": {
-        "psr-0": { "React\\Dns\\": "" }
+        "psr-4": { "React\\Dns\\": "" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
It was psr-0, but actually it should be psr-4, otherwise classes are not found.
