### PR TITLE
Updated to use string addresses.

### DIFF
--- a/tests/Query/ExecutorTest.php
+++ b/tests/Query/ExecutorTest.php
@@ -38,7 +38,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $this->executor
             ->expects($this->once())
             ->method('createConnection')
-            ->with('8.8.8.8:53', 'udp')
+            ->with('udp://8.8.8.8:53')
             ->will($this->returnNewConnectionMock());
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
@@ -54,7 +54,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $this->executor
             ->expects($this->once())
             ->method('createConnection')
-            ->with('8.8.8.8:53', 'tcp')
+            ->with('tcp://8.8.8.8:53')
             ->will($this->returnNewConnectionMock());
 
         $query = new Query(str_repeat('a', 512).'.igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
@@ -88,12 +88,12 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $this->executor
             ->expects($this->at(0))
             ->method('createConnection')
-            ->with('8.8.8.8:53', 'udp')
+            ->with('udp://8.8.8.8:53')
             ->will($this->returnNewConnectionMock());
         $this->executor
             ->expects($this->at(1))
             ->method('createConnection')
-            ->with('8.8.8.8:53', 'tcp')
+            ->with('tcp://8.8.8.8:53')
             ->will($this->returnNewConnectionMock());
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
@@ -120,7 +120,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $this->executor
             ->expects($this->once())
             ->method('createConnection')
-            ->with('8.8.8.8:53', 'tcp')
+            ->with('tcp://8.8.8.8:53')
             ->will($this->returnNewConnectionMock());
 
         $mock = $this->createCallableMock();
@@ -152,7 +152,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $this->executor
             ->expects($this->at(0))
             ->method('createConnection')
-            ->with('8.8.8.8:53', 'udp')
+            ->with('udp://8.8.8.8:53')
             ->will($this->returnNewConnectionMock());
 
 
@@ -178,7 +178,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $this->executor
             ->expects($this->at(0))
             ->method('createConnection')
-            ->with('8.8.8.8:53', 'udp')
+            ->with('udp://8.8.8.8:53')
             ->will($this->returnNewConnectionMock());
 
         $this->loop


### PR DESCRIPTION
Now fully supports string addresses, you can specify either the `tcp` or `udp` scheme, or leave it empty for backwards compatibility and to allow the executor to choose the best scheme:
- If you specify the `tcp` scheme, only that scheme will be used,
- If you specify the `udp` scheme, it may be switched to `tcp` if the first request fails,
- If you don't specify any scheme then either `tcp` or `udp` will be used depending on the query size.
