### PR TITLE
Replace React\Socket\Connection with client TCP/UDP connection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,9 @@
     "require": {
         "php": ">=5.4.0",
         "react/cache": "0.4.*",
-        "react/socket": "0.4.*",
-        "react/promise": "~2.0"
+        "react/socket-client": "0.4.x-dev",
+        "react/promise": "~2.0",
+        "react/datagram": "dev-master"
     },
     "autoload": {
         "psr-4": { "React\\Dns\\": "src" }


### PR DESCRIPTION
This is an _idea_ (and nothing more!) how the fix for https://github.com/reactphp/dns/issues/13 could look like.

This approach needs an additional PR against https://github.com/reactphp/socket-client/blob/master/src/Connector.php to allow creation with `null` Resolver (already allowed for the UDP socket).

The tests don't work due to the mock logic and I was not able to fix them, so not tested at all...
