### PR TITLE
Avoid hidding exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.3.0",
         "react/cache": "~0.4.0|~0.3.0",
         "react/socket": "~0.4.0|~0.3.0",
-        "react/promise": "~2.1|~1.2"
+        "react/promise": "~2.2"
     },
     "autoload": {
         "psr-4": { "React\\Dns\\": "src" }

--- a/src/Query/RecordCache.php
+++ b/src/Query/RecordCache.php
@@ -59,7 +59,7 @@ class RecordCache
                     return new RecordBag();
                 }
             )
-            ->then(function ($recordBag) use ($id, $currentTime, $record, $cache) {
+            ->done(function ($recordBag) use ($id, $currentTime, $record, $cache) {
                 $recordBag->set($currentTime, $record);
                 $cache->set($id, serialize($recordBag));
             });


### PR DESCRIPTION
`then()` catches exceptions, which is not desirable when its result is not returned.

When using the RetryExecutor, the exception thrown by the following code is caught, whereas it should not:

``` php
$executor = new Executor($loop, new Parser(), new BinaryDumper());
$executor = new RetryExecutor($executor);
$resolver = new Resolver('8.8.8.8:53', $executor);
$executor->resolve(null)
    // Once the promise is rejected, `done()` throws an exceptions, since there is no `onRejected` callback.
    // However, the exception is caught by RetryExecutor's `then()`.
    // This PR fixes this.
    ->done(function ($result) {
        ...
    });
```

The PR fixes this by changing some `then` to `done`.
