### PR TITLE
[RFC] Improve compatibility with legacy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "keywords": ["dns", "dns-resolver"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
-        "react/cache": "0.4.*",
-        "react/socket": "0.4.*",
-        "react/promise": "~2.0"
+        "php": ">=5.3.0",
+        "react/cache": "~0.4.0|~0.3.0",
+        "react/socket": "~0.4.0|~0.3.0",
+        "react/promise": "~2.0|~1.1"
     },
     "autoload": {
         "psr-4": { "React\\Dns\\": "src" }

--- a/src/Query/CachedExecutor.php
+++ b/src/Query/CachedExecutor.php
@@ -18,14 +18,15 @@ class CachedExecutor implements ExecutorInterface
 
     public function query($nameserver, Query $query)
     {
+        $that = $this;
         $executor = $this->executor;
         $cache = $this->cache;
 
         return $this->cache
             ->lookup($query)
             ->then(
-                function ($cachedRecords) use ($query) {
-                    return $this->buildResponse($query, $cachedRecords);
+                function ($cachedRecords) use ($that, $query) {
+                    return $that->buildResponse($query, $cachedRecords);
                 },
                 function () use ($executor, $cache, $nameserver, $query) {
                     return $executor

--- a/src/Query/Executor.php
+++ b/src/Query/Executor.php
@@ -48,14 +48,15 @@ class Executor implements ExecutorInterface
 
     public function doQuery($nameserver, $transport, $queryData, $name)
     {
+        $that = $this;
         $parser = $this->parser;
         $loop = $this->loop;
 
         $response = new Message();
         $deferred = new Deferred();
 
-        $retryWithTcp = function () use ($nameserver, $queryData, $name) {
-            return $this->doQuery($nameserver, 'tcp', $queryData, $name);
+        $retryWithTcp = function () use ($that, $nameserver, $queryData, $name) {
+            return $that->doQuery($nameserver, 'tcp', $queryData, $name);
         };
 
         $timer = $this->loop->addTimer($this->timeout, function () use (&$conn, $name, $deferred) {

--- a/src/Query/RetryExecutor.php
+++ b/src/Query/RetryExecutor.php
@@ -26,7 +26,8 @@ class RetryExecutor implements ExecutorInterface
 
     public function tryQuery($nameserver, Query $query, $retries, $deferred)
     {
-        $errorback = function ($error) use ($nameserver, $query, $retries, $deferred) {
+        $that = $this;
+        $errorback = function ($error) use ($nameserver, $query, $retries, $deferred, $that) {
             if (!$error instanceof TimeoutException) {
                 $deferred->reject($error);
                 return;
@@ -40,7 +41,7 @@ class RetryExecutor implements ExecutorInterface
                 $deferred->reject($error);
                 return;
             }
-            $this->tryQuery($nameserver, $query, $retries-1, $deferred);
+            $that->tryQuery($nameserver, $query, $retries-1, $deferred);
         };
 
         $this->executor

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -21,11 +21,12 @@ class Resolver
     public function resolve($domain)
     {
         $query = new Query($domain, Message::TYPE_A, Message::CLASS_IN, time());
+        $that = $this;
 
         return $this->executor
             ->query($this->nameserver, $query)
-            ->then(function (Message $response) use ($query) {
-                return $this->extractAddress($query, $response);
+            ->then(function (Message $response) use ($query, $that) {
+                return $that->extractAddress($query, $response);
             });
     }
 

--- a/tests/Query/ExecutorTest.php
+++ b/tests/Query/ExecutorTest.php
@@ -213,8 +213,9 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
     private function returnStandardResponse()
     {
-        $callback = function ($data, $response) {
-            $this->convertMessageToStandardResponse($response);
+        $that = $this;
+        $callback = function ($data, $response) use ($that) {
+            $that->convertMessageToStandardResponse($response);
             return $response;
         };
 
@@ -223,8 +224,9 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
     private function returnTruncatedResponse()
     {
-        $callback = function ($data, $response) {
-            $this->convertMessageToTruncatedResponse($response);
+        $that = $this;
+        $callback = function ($data, $response) use ($that) {
+            $that->convertMessageToTruncatedResponse($response);
             return $response;
         };
 


### PR DESCRIPTION
Because *why not*… :-)

Now more seriously: This project is a low level lib that is used as a building block for quite a few higher level abstractions on top of it. As such, compatibility (even with significantly outdated versions) is a major concern to me.

Note that I'm not suggesting putting *significant amount* of work into this. The patch is already here and, personally, I see little harm in supporting this.

Also note that I'm not suggesting we need to keep support indefinitely. Should this ever turn out to be a burden in the future, e.g. because we actually *require* any new language features or some external lib, then I'm all for dropping support again.