### PR TITLE
Resolving MX & NS Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ $dns->resolve('igor.io')->then(function ($ip) {
     echo "Host: $ip\n";
 });
 
+$dns->resolve('igor.io',\React\Dns\Model\Message::TYPE_MX)->then(function ($record) {
+    var_dump($record);//returns array of MX Records.
+});
+
+$dns->resolve('igor.io',\React\Dns\Model\Message::TYPE_NS)->then(function ($record) {
+    var_dump($record);//returns array of NS Records.
+});
+
+
 $loop->run();
 ```
 

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -106,7 +106,6 @@ class Parser
 
     public function parseAnswer(Message $message)
     {
-//        var_dump($message->data);die;
         if (strlen($message->data) < 2) {
             return;
         }

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -106,6 +106,7 @@ class Parser
 
     public function parseAnswer(Message $message)
     {
+//        var_dump($message->data);die;
         if (strlen($message->data) < 2) {
             return;
         }
@@ -144,6 +145,22 @@ class Parser
             list($bodyLabels, $consumed) = $this->readLabels($message->data, $consumed);
 
             $rdata = implode('.', $bodyLabels);
+        }
+
+        if (Message::TYPE_MX === $type) {
+
+            $consumed += 2;
+            list($bodyLabels, $consumed) = $this->readLabels($message->data, $consumed);
+
+            $rdata = implode('.', $bodyLabels);
+
+        }
+
+        if (Message::TYPE_NS === $type) {
+            list($bodyLabels, $consumed) = $this->readLabels($message->data, $consumed);
+
+            $rdata = implode('.', $bodyLabels);
+
         }
 
         $message->consumed = $consumed;

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -2,6 +2,8 @@
 
 namespace React\Dns\Query;
 
+use React\Dns\Model\Message;
+
 class Query
 {
     public $name;

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -32,6 +32,59 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function resolveShouldQueryMXRecords()
+    {
+        $record = array(
+            "ns3.linode.com",
+            "ns4.linode.com",
+            "ns1.linode.com",
+            "ns5.linode.com",
+            "ns2.linode.com"
+        );
+        $executor = $this->createExecutorMock();
+        $executor
+            ->expects($this->once())
+            ->method('query')
+            ->with($this->anything(), $this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($nameserver, $query) use ($record){
+                $response = new Message();
+                $response->header->set('qr', 1);
+                $response->questions[] = new Record($query->name, $query->type, $query->class);
+                $response->answers[] = new Record($query->name, $query->type, $query->class, 3600, $record);
+
+                return Promise\resolve($response);
+            }));
+
+        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver->resolve('igor.io')->then($this->expectCallableOnceWith($this->isType('array')));
+    }
+
+    /** @test */
+    public function resolveShouldQueryNSRecords()
+    {
+        $record = array(
+            "mx1.linode.com",
+            "mx2.linode.com"
+        );
+        $executor = $this->createExecutorMock();
+        $executor
+            ->expects($this->once())
+            ->method('query')
+            ->with($this->anything(), $this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($nameserver, $query) use ($record){
+                $response = new Message();
+                $response->header->set('qr', 1);
+                $response->questions[] = new Record($query->name, $query->type, $query->class);
+                $response->answers[] = new Record($query->name, $query->type, $query->class, 3600, $record);
+
+                return Promise\resolve($response);
+            }));
+
+        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver->resolve('igor.io')->then($this->expectCallableOnceWith($this->isType('array')));
+    }
+
+    /** @test */
     public function resolveShouldFilterByName()
     {
         $executor = $this->createExecutorMock();


### PR DESCRIPTION
Implement message body parsing for types #31 partial implementation. MX AND NS Records.
1. function resolve() in Resolver Class now takes a type argument and defaults to A Record if none is passed.
2. Query for MX and NS records returns an array.
3. For MX queries priority is not captured in the current pull request.
