### PR TITLE
Allow for cache adapter injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The second result will be served from cache.
 
 ### Custom cache adapter
 
-You can also specify a cache that [implements](https://github.com/reactphp/react/wiki/Users#cache-implmentations) [`CacheInterface`](https://github.com/reactphp/cache) to handle the record cache instead of the default in memory cache. 
+You can also specify a cache that [implements](https://github.com/reactphp/react/wiki/Users#cache-implementations) [`CacheInterface`](https://github.com/reactphp/cache) to handle the record cache instead of the default in memory cache. 
 
 ```php
 $cache = new React\Cache\ArrayCache();

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ $loop->run();
 If the first call returns before the second, only one query will be executed.
 The second result will be served from cache.
 
+### Custom cache adapter
+
+You can also specify a cache that [implements](https://github.com/reactphp/react/wiki/Users#cache-implmentations) [`CacheInterface`](https://github.com/reactphp/cache) to handle the record cache instead of the default in memory cache. 
+
+```php
+$cache = new React\Cache\ArrayCache();
+$loop = React\EventLoop\Factory::create();
+$factory = new React\Dns\Resolver\Factory();
+$dns = $factory->createCached('8.8.8.8', $loop, $cache);
+```
+
 ## Install
 
 The recommended way to install this library is [through Composer](http://getcomposer.org).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ The second result will be served from cache.
 
 ### Custom cache adapter
 
-You can also specify a cache that [implements](https://github.com/reactphp/react/wiki/Users#cache-implementations) [`CacheInterface`](https://github.com/reactphp/cache) to handle the record cache instead of the default in memory cache. 
+By default, the above will use an in memory cache.
+
+You can also specify a custom cache implementing [`CacheInterface`](https://github.com/reactphp/cache) to handle the record cache instead:
 
 ```php
 $cache = new React\Cache\ArrayCache();
@@ -63,6 +65,8 @@ $loop = React\EventLoop\Factory::create();
 $factory = new React\Dns\Resolver\Factory();
 $dns = $factory->createCached('8.8.8.8', $loop, $cache);
 ```
+
+See also the wiki for possible [cache implementations](https://github.com/reactphp/react/wiki/Users#cache-implementations).
 
 ## Install
 

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -42,8 +42,9 @@ class FactoryTest extends TestCase
         $executor = $this->getResolverPrivateMemberValue($resolver, 'executor');
         $this->assertInstanceOf('React\Dns\Query\CachedExecutor', $executor);
         $recordCache = $this->getCachedExecutorPrivateMemberValue($executor, 'cache');
-        $this->assertInstanceOf('React\Cache\CacheInterface', $this->getRecordCachePrivateMemberValue($recordCache, 'cache'));
-        $this->assertInstanceOf('React\Cache\ArrayCache', $this->getRecordCachePrivateMemberValue($recordCache, 'cache'));
+        $recordCacheCache = $this->getRecordCachePrivateMemberValue($recordCache, 'cache');
+        $this->assertInstanceOf('React\Cache\CacheInterface', $recordCacheCache);
+        $this->assertInstanceOf('React\Cache\ArrayCache', $recordCacheCache);
     }
 
     /** @test */
@@ -59,8 +60,9 @@ class FactoryTest extends TestCase
         $executor = $this->getResolverPrivateMemberValue($resolver, 'executor');
         $this->assertInstanceOf('React\Dns\Query\CachedExecutor', $executor);
         $recordCache = $this->getCachedExecutorPrivateMemberValue($executor, 'cache');
-        $this->assertInstanceOf('React\Cache\CacheInterface', $this->getRecordCachePrivateMemberValue($recordCache, 'cache'));
-        $this->assertSame($cache, $this->getRecordCachePrivateMemberValue($recordCache, 'cache'));
+        $recordCacheCache = $this->getRecordCachePrivateMemberValue($recordCache, 'cache');
+        $this->assertInstanceOf('React\Cache\CacheInterface', $recordCacheCache);
+        $this->assertSame($cache, $recordCacheCache);
     }
 
     /**

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -39,7 +39,11 @@ class FactoryTest extends TestCase
         $resolver = $factory->createCached('8.8.8.8:53', $loop);
 
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
-        $this->assertInstanceOf('React\Dns\Query\CachedExecutor', $this->getResolverPrivateMemberValue($resolver, 'executor'));
+        $executor = $this->getResolverPrivateMemberValue($resolver, 'executor');
+        $this->assertInstanceOf('React\Dns\Query\CachedExecutor', $executor);
+        $recordCache = $this->getCachedExecutorPrivateMemberValue($executor, 'cache');
+        $this->assertInstanceOf('React\Cache\CacheInterface', $this->getRecordCachePrivateMemberValue($recordCache, 'cache'));
+        $this->assertInstanceOf('React\Cache\ArrayCache', $this->getRecordCachePrivateMemberValue($recordCache, 'cache'));
     }
 
     /** @test */

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -42,6 +42,23 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('React\Dns\Query\CachedExecutor', $this->getResolverPrivateMemberValue($resolver, 'executor'));
     }
 
+    /** @test */
+    public function createCachedShouldCreateResolverWithCachedExecutorWithCustomCache()
+    {
+        $cache = $this->getMock('React\Cache\CacheInterface');
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $factory = new Factory();
+        $resolver = $factory->createCached('8.8.8.8:53', $loop, $cache);
+
+        $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
+        $executor = $this->getResolverPrivateMemberValue($resolver, 'executor');
+        $this->assertInstanceOf('React\Dns\Query\CachedExecutor', $executor);
+        $recordCache = $this->getCachedExecutorPrivateMemberValue($executor, 'cache');
+        $this->assertInstanceOf('React\Cache\CacheInterface', $this->getRecordCachePrivateMemberValue($recordCache, 'cache'));
+        $this->assertSame($cache, $this->getRecordCachePrivateMemberValue($recordCache, 'cache'));
+    }
+
     /**
      * @test
      * @dataProvider factoryShouldAddDefaultPortProvider
@@ -72,6 +89,20 @@ class FactoryTest extends TestCase
     private function getResolverPrivateMemberValue($resolver, $field)
     {
         $reflector = new \ReflectionProperty('React\Dns\Resolver\Resolver', $field);
+        $reflector->setAccessible(true);
+        return $reflector->getValue($resolver);
+    }
+
+    private function getCachedExecutorPrivateMemberValue($resolver, $field)
+    {
+        $reflector = new \ReflectionProperty('React\Dns\Query\CachedExecutor', $field);
+        $reflector->setAccessible(true);
+        return $reflector->getValue($resolver);
+    }
+
+    private function getRecordCachePrivateMemberValue($resolver, $field)
+    {
+        $reflector = new \ReflectionProperty('React\Dns\Query\RecordCache', $field);
         $reflector->setAccessible(true);
         return $reflector->getValue($resolver);
     }


### PR DESCRIPTION
While developing [wyrihaximus/react-cache-redis](https://github.com/wyrihaximus/reactphp-cache-redis) I've noticed that passing your own cache implementation into the resolver is [suboptimal](https://gist.github.com/WyriHaximus/43284f356a1ce7021cf4a44c43ed128f) compared to the proposed change.

To do:
- [X] Implement cache adapter injection
- [x] Tests
- [x] Documentation