### PR TITLE
Fix handling connection errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.3.0",
         "react/cache": "~0.4.0|~0.3.0",
-        "react/socket": "~0.4.0|~0.3.0",
+        "react/socket": "^0.4.4",
         "react/promise": "~2.1|~1.2"
     },
     "autoload": {

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -45,4 +45,13 @@ class FunctionalTest extends TestCase
 
         $this->assertLessThan(0.1, $time);
     }
+
+    public function testInvalidResolverDoesNotResolveGoogle()
+    {
+        $factory = new Factory();
+        $this->resolver = $factory->create('255.255.255.255', $this->loop);
+
+        $promise = $this->resolver->resolve('google.com');
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
 }

--- a/tests/Query/ExecutorTest.php
+++ b/tests/Query/ExecutorTest.php
@@ -101,8 +101,6 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function resolveShouldRetryWithTcpIfResponseIsTruncated()
     {
-        $conn = $this->createConnectionMock();
-
         $timer = $this->getMock('React\EventLoop\Timer\TimerInterface');
 
         $this->loop
@@ -135,6 +133,79 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
         $this->executor->query('8.8.8.8:53', $query, function () {}, function () {});
+    }
+
+    /** @test */
+    public function resolveShouldRetryWithTcpIfUdpThrows()
+    {
+        $timer = $this->getMock('React\EventLoop\Timer\TimerInterface');
+
+        $this->loop
+            ->expects($this->once())
+            ->method('addTimer')
+            ->will($this->returnValue($timer));
+
+        $this->parser
+            ->expects($this->once())
+            ->method('parseChunk')
+            ->with($this->anything(), $this->isInstanceOf('React\Dns\Model\Message'))
+            ->will($this->returnStandardResponse());
+
+        $this->executor = $this->createExecutorMock();
+        $this->executor
+            ->expects($this->at(0))
+            ->method('createConnection')
+            ->with('8.8.8.8:53', 'udp')
+            ->will($this->throwException(new \Exception()));
+        $this->executor
+            ->expects($this->at(1))
+            ->method('createConnection')
+            ->with('8.8.8.8:53', 'tcp')
+            ->will($this->returnNewConnectionMock());
+
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
+        $this->executor->query('8.8.8.8:53', $query, function () {}, function () {});
+    }
+
+    /** @test */
+    public function resolveShouldFailIfBothUdpAndTcpThrow()
+    {
+        $timer = $this->getMock('React\EventLoop\Timer\TimerInterface');
+
+        $this->loop
+            ->expects($this->once())
+            ->method('addTimer')
+            ->will($this->returnValue($timer));
+
+        $this->parser
+            ->expects($this->never())
+            ->method('parseChunk');
+
+        $this->executor = $this->createExecutorMock();
+        $this->executor
+            ->expects($this->at(0))
+            ->method('createConnection')
+            ->with('8.8.8.8:53', 'udp')
+            ->will($this->throwException(new \Exception()));
+        $this->executor
+            ->expects($this->at(1))
+            ->method('createConnection')
+            ->with('8.8.8.8:53', 'tcp')
+            ->will($this->throwException(new \Exception()));
+
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
+        $promise = $this->executor->query('8.8.8.8:53', $query, function () {}, function () {});
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->callback(function($e) {
+                return $e instanceof \RuntimeException &&
+                    strpos($e->getMessage(), 'Unable to connect to DNS server') === 0;
+            }));
+
+        $promise->then($this->expectCallableNever(), $mock);
     }
 
     /** @test */


### PR DESCRIPTION
Currently, a connection error will throw an uncaught exception that will bubble up to the upper-most exception handler.

This PR changes it to simply reject the promise as excepted.

Note that this does not address #19, i.e. the connection is still blocking.
I'll file a new PR for this (unrelated issue) soon.

Fixes / closes #16 
Fixes / closes #13
Supersedes / closes #22 