### PR TITLE
Support Socket component v0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.3.0",
         "react/cache": "~0.4.0|~0.3.0",
-        "react/socket": "^0.4.4",
+        "react/socket": "^0.5 || ^0.4.4",
         "react/promise": "~2.1|~1.2"
     },
     "autoload": {


### PR DESCRIPTION
Support upcoming Socket v0.5 release. Socket v0.5 contains some breaking changes, but this component is actually fully compatible.

The Socket v0.5 release is *not* out yet, but we'll have to update this component first, because there would otherwise be no installation candidate for when Socket v0.5 tries to install DNS v0.4.* due to its circular dependency.

Ultimately, this dependency should eventually be removed via #12 and #19, but this will require a rather bigger change in the future and a potential BC break.