### PR TITLE
Add TimeoutExecutor decorator 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "php": ">=5.3.0",
         "react/cache": "~0.4.0|~0.3.0",
         "react/socket": "^0.5 || ^0.4.4",
-        "react/promise": "~2.1|~1.2"
+        "react/promise": "~2.1|~1.2",
+        "react/promise-timer": "~1.1"
     },
     "autoload": {
         "psr-4": { "React\\Dns\\": "src" }

--- a/src/Query/Executor.php
+++ b/src/Query/Executor.php
@@ -19,10 +19,14 @@ class Executor implements ExecutorInterface
 
     /**
      *
+     * Note that albeit supported, the $timeout parameter is deprecated!
+     * You should pass a `null` value here instead. If you need timeout handling,
+     * use the `TimeoutConnector` instead.
+     *
      * @param LoopInterface $loop
      * @param Parser $parser
      * @param BinaryDumper $dumper
-     * @param float|null $timeout timeout for DNS query or NULL=no timeout
+     * @param null|float $timeout DEPRECATED: timeout for DNS query or NULL=no timeout
      */
     public function __construct(LoopInterface $loop, Parser $parser, BinaryDumper $dumper, $timeout = 5)
     {

--- a/src/Query/TimeoutExecutor.php
+++ b/src/Query/TimeoutExecutor.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace React\Dns\Query;
+
+use React\EventLoop\LoopInterface;
+use React\Promise\Deferred;
+use React\Promise\CancellablePromiseInterface;
+
+class TimeoutExecutor implements ExecutorInterface
+{
+    private $executor;
+    private $loop;
+    private $timeout;
+
+    public function __construct(ExecutorInterface $executor, $timeout, LoopInterface $loop)
+    {
+        $this->executor = $executor;
+        $this->loop = $loop;
+        $this->timeout = $timeout;
+    }
+
+    public function query($nameserver, Query $query)
+    {
+        $name = $query->name;
+
+        $deferred = new Deferred(function ($resolve, $reject) use (&$promise) {
+            $reject(new CancellationException('Cancelled'));
+            if ($promise instanceof CancellablePromiseInterface) {
+                $promise->cancel();
+            }
+        });
+
+        $timer = $this->loop->addTimer($this->timeout, function () use ($name, $deferred, &$promise) {
+            $deferred->reject(new TimeoutException(sprintf("DNS query for %s timed out", $name)));
+            if ($promise instanceof CancellablePromiseInterface) {
+                $promise->cancel();
+            }
+        });
+
+        $promise = $this->executor->query($nameserver, $query);
+
+        $promise->then(
+            function ($result) use ($timer, $deferred) {
+                $timer->cancel();
+                $deferred->resolve($result);
+            },
+            function ($e) use ($timer, $deferred) {
+                $timer->cancel();
+                $deferred->reject($e);
+            }
+        );
+
+        return $deferred->promise();
+    }
+}

--- a/src/Query/TimeoutExecutor.php
+++ b/src/Query/TimeoutExecutor.php
@@ -5,6 +5,7 @@ namespace React\Dns\Query;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use React\Promise\CancellablePromiseInterface;
+use React\Promise\Timer;
 
 class TimeoutExecutor implements ExecutorInterface
 {
@@ -21,35 +22,11 @@ class TimeoutExecutor implements ExecutorInterface
 
     public function query($nameserver, Query $query)
     {
-        $name = $query->name;
-
-        $deferred = new Deferred(function ($resolve, $reject) use (&$promise) {
-            $reject(new CancellationException('Cancelled'));
-            if ($promise instanceof CancellablePromiseInterface) {
-                $promise->cancel();
+        return Timer\timeout($this->executor->query($nameserver, $query), $this->timeout, $this->loop)->then(null, function ($e) use ($query) {
+            if ($e instanceof Timer\TimeoutException) {
+                $e = new TimeoutException(sprintf("DNS query for %s timed out", $query->name), 0, $e);
             }
+            throw $e;
         });
-
-        $timer = $this->loop->addTimer($this->timeout, function () use ($name, $deferred, &$promise) {
-            $deferred->reject(new TimeoutException(sprintf("DNS query for %s timed out", $name)));
-            if ($promise instanceof CancellablePromiseInterface) {
-                $promise->cancel();
-            }
-        });
-
-        $promise = $this->executor->query($nameserver, $query);
-
-        $promise->then(
-            function ($result) use ($timer, $deferred) {
-                $timer->cancel();
-                $deferred->resolve($result);
-            },
-            function ($e) use ($timer, $deferred) {
-                $timer->cancel();
-                $deferred->reject($e);
-            }
-        );
-
-        return $deferred->promise();
     }
 }

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -11,6 +11,7 @@ use React\Dns\Protocol\Parser;
 use React\Dns\Protocol\BinaryDumper;
 use React\EventLoop\LoopInterface;
 use React\Dns\Query\RetryExecutor;
+use React\Dns\Query\TimeoutExecutor;
 
 class Factory
 {
@@ -36,7 +37,11 @@ class Factory
 
     protected function createExecutor(LoopInterface $loop)
     {
-        return new Executor($loop, new Parser(), new BinaryDumper());
+        return new TimeoutExecutor(
+            new Executor($loop, new Parser(), new BinaryDumper(), null),
+            5.0,
+            $loop
+        );
     }
 
     protected function createRetryExecutor(LoopInterface $loop)

--- a/tests/Query/ExecutorTest.php
+++ b/tests/Query/ExecutorTest.php
@@ -10,6 +10,11 @@ use React\Dns\Protocol\BinaryDumper;
 
 class ExecutorTest extends \PHPUnit_Framework_TestCase
 {
+    private $loop;
+    private $parser;
+    private $dumper;
+    private $executor;
+
     public function setUp()
     {
         $this->loop = $this->getMock('React\EventLoop\LoopInterface');
@@ -94,6 +99,32 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
                 $this->attribute($this->equalTo('DNS query for igor.io has been cancelled'), 'message')
             )
         );
+
+        $promise->then($this->expectCallableNever(), $errorback);
+    }
+
+    /** @test */
+    public function resolveShouldNotStartOrCancelTimerWhenCancelledWithTimeoutIsNull()
+    {
+        $this->loop
+            ->expects($this->never())
+            ->method('addTimer');
+
+        $this->executor = new Executor($this->loop, $this->parser, $this->dumper, null);
+
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
+        $promise = $this->executor->query('8.8.8.8:53', $query);
+
+        $promise->cancel();
+
+        $errorback = $this->createCallableMock();
+        $errorback
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->logicalAnd(
+                $this->isInstanceOf('React\Dns\Query\CancellationException'),
+                $this->attribute($this->equalTo('DNS query for igor.io has been cancelled'), 'message')
+            ));
 
         $promise->then($this->expectCallableNever(), $errorback);
     }

--- a/tests/Query/TimeoutExecutorTest.php
+++ b/tests/Query/TimeoutExecutorTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace React\Tests\Dns\Query;
+
+use React\Dns\Query\TimeoutExecutor;
+use React\Dns\Query\Query;
+use React\Dns\Model\Message;
+use React\Promise\Deferred;
+use React\Dns\Query\CancellationException;
+use React\Tests\Dns\TestCase;
+
+class TimeoutExecutorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $this->wrapped = $this->getMock('React\Dns\Query\ExecutorInterface');
+
+        $this->executor = new TimeoutExecutor($this->wrapped, 5.0, $this->loop);
+    }
+
+    public function testCancelWrappedWhenCancelled()
+    {
+        if (!interface_exists('React\Promise\CancellablePromiseInterface')) {
+            $this->markTestSkipped('Skipped missing CancellablePromiseInterface');
+        }
+
+        $cancelled = 0;
+
+        $this->wrapped
+            ->expects($this->once())
+            ->method('query')
+            ->will($this->returnCallback(function ($domain, $query) use (&$cancelled) {
+                $deferred = new Deferred(function ($resolve, $reject) use (&$cancelled) {
+                    ++$cancelled;
+                    $reject(new CancellationException('Cancelled'));
+                });
+
+                return $deferred->promise();
+            }));
+
+        $timer = $this->getMock('React\EventLoop\Timer\TimerInterface');
+        $timer
+            ->expects($this->once())
+            ->method('cancel');
+
+        $this->loop
+            ->expects($this->once())
+            ->method('addTimer')
+            ->with(5, $this->isInstanceOf('Closure'))
+            ->will($this->returnValue($timer));
+
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
+        $promise = $this->executor->query('8.8.8.8:53', $query);
+
+
+        $this->assertEquals(0, $cancelled);
+        $promise->cancel();
+        $this->assertEquals(1, $cancelled);
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
+
+    public function testCancelTimerWhenWrappedResolves()
+    {
+        $deferred = new Deferred();
+
+        $this->wrapped
+            ->expects($this->once())
+            ->method('query')
+            ->will($this->returnCallback(function ($domain, $query) use ($deferred) {
+                return $deferred->promise();
+            }));
+
+        $timer = $this->getMock('React\EventLoop\Timer\TimerInterface');
+        $timer
+            ->expects($this->once())
+            ->method('cancel');
+
+        $this->loop
+            ->expects($this->once())
+            ->method('addTimer')
+            ->with(5, $this->isInstanceOf('Closure'))
+            ->will($this->returnValue($timer));
+
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
+        $promise = $this->executor->query('8.8.8.8:53', $query);
+
+        $promise->then($this->expectCallableOnce(), $this->expectCallableNever());
+
+        $deferred->resolve('0.0.0.0');
+    }
+
+    public function testWrappedWillBeCancelledOnTimeout()
+    {
+        if (!interface_exists('React\Promise\CancellablePromiseInterface')) {
+            $this->markTestSkipped('Skipped missing CancellablePromiseInterface');
+        }
+
+        $cancelled = 0;
+
+        $this->wrapped
+            ->expects($this->once())
+            ->method('query')
+            ->will($this->returnCallback(function ($domain, $query) use (&$cancelled) {
+                $deferred = new Deferred(function ($resolve, $reject) use (&$cancelled) {
+                    ++$cancelled;
+                    $reject(new CancellationException('Cancelled'));
+                });
+
+                return $deferred->promise();
+            }));
+
+        $timer = $this->getMock('React\EventLoop\Timer\TimerInterface');
+        $timer
+            ->expects($this->any())
+            ->method('cancel');
+
+        $this->loop
+            ->expects($this->once())
+            ->method('addTimer')
+            ->with(5, $this->isInstanceOf('Closure'))
+            ->will($this->returnCallback(function ($time, $callback) use (&$timerCallback, &$timer) {
+                $timerCallback = $callback;
+                return $timer;
+            }));
+
+        $this->loop
+            ->expects($this->never())
+            ->method('cancelTimer');
+
+        $callback = $this->expectCallableNever();
+
+        $errorback = $this->createCallableMock();
+        $errorback
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->logicalAnd(
+                $this->isInstanceOf('React\Dns\Query\TimeoutException'),
+                $this->attribute($this->equalTo('DNS query for igor.io timed out'), 'message')
+            ));
+
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
+        $this->executor->query('8.8.8.8:53', $query)->then($callback, $errorback);
+
+        $this->assertNotNull($timerCallback);
+
+        $this->assertEquals(0, $cancelled);
+        $timerCallback();
+        $this->assertEquals(1, $cancelled);
+    }
+}


### PR DESCRIPTION
The `Executor` violates SRP, so this PR is a first step to break this up into multiple independent classes.

This PR preserves full BC by making its timeout feature optional first and then using a `TimeoutExecutor` decorator instead. This can also be reused for other components, in particular clue/mdns-react. Also, this is needed for upcoming changes related to #12 and #19 which will introduce new executor classes that will reuse this timeout handling.

Builds on top of #35 
Somewhat similar to https://github.com/reactphp/socket-client/pull/51