### PR TITLE
Add simpler internal API

### DIFF
--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -2,6 +2,8 @@
 
 namespace React\Dns\Model;
 
+use React\Dns\Query\Query;
+
 class Message
 {
     const TYPE_A = 1;
@@ -24,6 +26,28 @@ class Message
     const RCODE_NAME_ERROR = 3;
     const RCODE_NOT_IMPLEMENTED = 4;
     const RCODE_REFUSED = 5;
+
+    /**
+     * Creates a new request message for the given query
+     *
+     * @param Query $query
+     * @return self
+     */
+    public static function createRequestForQuery(Query $query)
+    {
+        $request = new Message();
+        $request->header->set('id', self::generateId());
+        $request->header->set('rd', 1);
+        $request->questions[] = (array) $query;
+        $request->prepare();
+
+        return $request;
+    }
+
+    private static function generateId()
+    {
+        return mt_rand(0, 0xffff);
+    }
 
     public $data = '';
 

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -3,6 +3,7 @@
 namespace React\Dns\Model;
 
 use React\Dns\Query\Query;
+use React\Dns\Model\Record;
 
 class Message
 {
@@ -42,6 +43,33 @@ class Message
         $request->prepare();
 
         return $request;
+    }
+
+    /**
+     * Creates a new response message for the given query with the given answer records
+     *
+     * @param Query    $query
+     * @param Record[] $answers
+     * @return self
+     */
+    public static function createResponseWithAnswersForQuery(Query $query, array $answers)
+    {
+        $response = new Message();
+        $response->header->set('id', self::generateId());
+        $response->header->set('qr', 1);
+        $response->header->set('opcode', Message::OPCODE_QUERY);
+        $response->header->set('rd', 1);
+        $response->header->set('rcode', Message::RCODE_OK);
+
+        $response->questions[] = (array) $query;
+
+        foreach ($answers as $record) {
+            $response->answers[] = $record;
+        }
+
+        $response->prepare();
+
+        return $response;
     }
 
     private static function generateId()

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -4,6 +4,7 @@ namespace React\Dns\Protocol;
 
 use React\Dns\Model\Message;
 use React\Dns\Model\Record;
+use InvalidArgumentException;
 
 /**
  * DNS protocol parser
@@ -12,7 +13,32 @@ use React\Dns\Model\Record;
  */
 class Parser
 {
+    /**
+     * Parses the given raw binary message into a Message object
+     *
+     * @param string $data
+     * @throws InvalidArgumentException
+     * @return Message
+     */
+    public function parseMessage($data)
+    {
+        $message = new Message();
+        if ($this->parse($data, $message) !== $message) {
+            throw new InvalidArgumentException('Unable to parse binary message');
+        }
+
+        return $message;
+    }
+
+    /**
+     * @deprecated unused, exists for BC only
+     */
     public function parseChunk($data, Message $message)
+    {
+        return $this->parse($data, $message);
+    }
+
+    private function parse($data, Message $message)
     {
         $message->data .= $data;
 

--- a/src/Query/Executor.php
+++ b/src/Query/Executor.php
@@ -38,7 +38,7 @@ class Executor implements ExecutorInterface
 
     public function query($nameserver, Query $query)
     {
-        $request = $this->prepareRequest($query);
+        $request = Message::createRequestForQuery($query);
 
         $queryData = $this->dumper->toBinary($request);
         $transport = strlen($queryData) > 512 ? 'tcp' : 'udp';
@@ -46,15 +46,12 @@ class Executor implements ExecutorInterface
         return $this->doQuery($nameserver, $transport, $queryData, $query->name);
     }
 
+    /**
+     * @deprecated unused, exists for BC only
+     */
     public function prepareRequest(Query $query)
     {
-        $request = new Message();
-        $request->header->set('id', $this->generateId());
-        $request->header->set('rd', 1);
-        $request->questions[] = (array) $query;
-        $request->prepare();
-
-        return $request;
+        return Message::createRequestForQuery($query);
     }
 
     public function doQuery($nameserver, $transport, $queryData, $name)
@@ -139,6 +136,9 @@ class Executor implements ExecutorInterface
         return $deferred->promise();
     }
 
+    /**
+     * @deprecated unused, exists for BC only
+     */
     protected function generateId()
     {
         return mt_rand(0, 0xffff);

--- a/tests/Model/MessageTest.php
+++ b/tests/Model/MessageTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace React\Tests\Dns\Model;
+
+use React\Dns\Query\Query;
+use React\Dns\Model\Message;
+
+class MessageTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateRequestDesiresRecusion()
+    {
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
+        $request = Message::createRequestForQuery($query);
+
+        $this->assertTrue($request->header->isQuery());
+        $this->assertSame(1, $request->header->get('rd'));
+    }
+}

--- a/tests/Model/MessageTest.php
+++ b/tests/Model/MessageTest.php
@@ -15,4 +15,15 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($request->header->isQuery());
         $this->assertSame(1, $request->header->get('rd'));
     }
+
+    public function testCreateResponseWithNoAnswers()
+    {
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
+        $answers = array();
+        $request = Message::createResponseWithAnswersForQuery($query, $answers);
+
+        $this->assertFalse($request->header->isQuery());
+        $this->assertTrue($request->header->isResponse());
+        $this->assertEquals(0, $request->header->get('anCount'));
+    }
 }

--- a/tests/Query/ExecutorTest.php
+++ b/tests/Query/ExecutorTest.php
@@ -25,16 +25,6 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function prepareRequestShouldCreateRequestWithRecursionDesired()
-    {
-        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
-        $request = $this->executor->prepareRequest($query);
-
-        $this->assertTrue($request->header->isQuery());
-        $this->assertSame(1, $request->header->get('rd'));
-    }
-
-    /** @test */
     public function queryShouldCreateUdpRequest()
     {
         $timer = $this->getMock('React\EventLoop\Timer\TimerInterface');


### PR DESCRIPTION
The `Executor` violates SRP, so this PR is a first step to break this up into multiple independent responsibilities.

This PR preserves full BC by adding some new internal APIs first and then deprecate the existing internal API. This can also be reused for other components, in particular clue/mdns-react. Also, this is needed for upcoming changes related to #12 and #19 which will introduce new executor classes that will reuse these methods.

If you want to review, consider looking at the individual commits instead.

Refs #48.