### PR TITLE
Set `bufferSize` to null to fix Windows 10 timeout issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.3.0",
         "react/cache": "~0.4.0|~0.3.0",
         "react/socket": "^0.5 || ^0.4.5",
-        "react/promise": "~2.1|~1.2"
+        "react/promise": "~2.1|~1.2",
         "react/promise-timer": "~1.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.3.0",
         "react/cache": "~0.4.0|~0.3.0",
-        "react/socket": "^0.4.5",
+        "react/socket": "^0.5 || ^0.4.5",
         "react/promise": "~2.1|~1.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.3.0",
         "react/cache": "~0.4.0|~0.3.0",
-        "react/socket": "^0.5 || ^0.4.4",
+        "react/socket": "^0.4.5",
         "react/promise": "~2.1|~1.2"
     },
     "autoload": {

--- a/src/Query/Executor.php
+++ b/src/Query/Executor.php
@@ -108,6 +108,7 @@ class Executor implements ExecutorInterface
         $fd = stream_socket_client("$transport://$nameserver", $errno, $errstr, 0, STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT);
         stream_set_blocking($fd, 0);
         $conn = new Connection($fd, $this->loop);
+        $conn->bufferSize = null; // Temporary fix for Windows 10 users
 
         return $conn;
     }


### PR DESCRIPTION
Fixes #44, not tested as I do not have a Windows 10 machine.