### PR TITLE
Ensure we ignore the case of the answer

### DIFF
--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -85,8 +85,9 @@ class Resolver
 
     private function filterByField(array $answers, $field, $value)
     {
+        $value = strtolower($value);
         return array_filter($answers, function ($answer) use ($field, $value) {
-            return strtolower($value) === strtolower($answer->$field);
+            return $value === strtolower($answer->$field);
         });
     }
 

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -86,7 +86,7 @@ class Resolver
     private function filterByField(array $answers, $field, $value)
     {
         return array_filter($answers, function ($answer) use ($field, $value) {
-            return $value === $answer->$field;
+            return strtolower($value) === strtolower($answer->$field);
         });
     }
 


### PR DESCRIPTION
Came across this while working on #52, testing it against `blog.wyrihaximus.net` (which is a `CNAME` for my blog hosted on amazon cloudfront) yielded `Blog.wyrihaximus.net` as answer. The filter used in the resolver is case sensitive, this PR ensure's it isn't. 