### PR TITLE
Fix DNS timeout issues for Windows users and add forward compatibility with Stream v0.5 and upcoming v0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": ">=5.3.0",
         "react/cache": "~0.4.0|~0.3.0",
         "react/socket": "^0.5 || ^0.4.4",
+        "react/stream": "^0.6 || ^0.5 || ^0.4.5",
         "react/promise": "~2.1|~1.2",
         "react/promise-timer": "~1.1"
     },

--- a/src/Query/Executor.php
+++ b/src/Query/Executor.php
@@ -148,6 +148,7 @@ class Executor implements ExecutorInterface
     {
         $fd = @stream_socket_client("$transport://$nameserver", $errno, $errstr, 0, STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT);
         $conn = new Connection($fd, $this->loop);
+        $conn->bufferSize = null; // Temporary fix for Windows 10 users
 
         return $conn;
     }


### PR DESCRIPTION
This component is in fact already compatible with v0.4, the new v0.5 and the upcoming v0.6, see also https://github.com/reactphp/stream/issues/67.

Supersedes / closes #50

Depends on https://github.com/reactphp/socket/pull/79