### PR TITLE
Resolver::resolveAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ $promise = $resolver->resolve('reactphp.org');
 $promise->cancel();
 ```
 
+Where `resolve` only returns one record but there is also `resolveAll` which returns all records.
+
+```php
+$loop = React\EventLoop\Factory::create();
+
+$factory = new React\Dns\Resolver\Factory();
+$resolver = $factory->create('8.8.8.8', $loop);
+
+$resolver->resolveAll('blog.wyrihaximus.net')->done(function ($ips) use ($name) {
+    foreach ($ips as $ip) {
+        echo "Host: $ip\n";
+    }
+});
+
+$loop->run();
+```
+
+See also the [fith example](examples).
+
 But there's more.
 
 ## Caching

--- a/examples/05-all-for-one.php
+++ b/examples/05-all-for-one.php
@@ -1,0 +1,20 @@
+<?php
+
+use React\Dns\Resolver\Factory;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = React\EventLoop\Factory::create();
+
+$factory = new Factory();
+$resolver = $factory->create('8.8.8.8', $loop);
+
+$name = isset($argv[1]) ? $argv[1] : 'blog.wyrihaximus.net';
+
+$resolver->resolveAll($name)->then(function ($ips) use ($name) {
+    foreach ($ips as $ip) {
+        echo 'IP for ' . $name . ': ' . $ip . PHP_EOL;
+    }
+}, 'printf');
+
+$loop->run();

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -37,6 +37,12 @@ class Resolver
             });
     }
 
+    public function extractAddress(Query $query, Message $response)
+    {
+        $addresses = $this->extractAddresses($query, $response);
+        return $addresses[array_rand($addresses)];
+    }
+
     public function extractAddresses(Query $query, Message $response)
     {
         $answers = $response->answers;

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -20,17 +20,24 @@ class Resolver
 
     public function resolve($domain)
     {
+        return $this->resolveAll($domain)->then(function ($addresses) {
+                return $addresses[array_rand($addresses)];
+            });
+    }
+
+    public function resolveAll($domain)
+    {
         $query = new Query($domain, Message::TYPE_A, Message::CLASS_IN, time());
         $that = $this;
 
         return $this->executor
             ->query($this->nameserver, $query)
             ->then(function (Message $response) use ($query, $that) {
-                return $that->extractAddress($query, $response);
+                return $that->extractAddresses($query, $response);
             });
     }
 
-    public function extractAddress(Query $query, Message $response)
+    public function extractAddresses(Query $query, Message $response)
     {
         $answers = $response->answers;
 
@@ -41,8 +48,7 @@ class Resolver
             throw new RecordNotFoundException($message);
         }
 
-        $address = $addresses[array_rand($addresses)];
-        return $address;
+        return $addresses;
     }
 
     public function resolveAliases(array $answers, $name)

--- a/tests/Resolver/ResolveAliasesTest.php
+++ b/tests/Resolver/ResolveAliasesTest.php
@@ -18,7 +18,7 @@ class ResolveAliasesTest extends \PHPUnit_Framework_TestCase
         $executor = $this->createExecutorMock();
         $resolver = new Resolver('8.8.8.8:53', $executor);
 
-        $answers = $resolver->resolveAliases($answers, $name);
+        $answers = $resolver->resolveAliases($answers, $name, Message::TYPE_A);
 
         $this->assertEquals($expectedAnswers, $answers);
     }

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -141,7 +141,7 @@ class ResolverTest extends TestCase
             }));
 
         $resolver = new Resolver('8.8.8.8:53', $executor);
-        $resolver->resolveAll('igor.io')->then($this->expectCallableOnceWith(['178.79.169.131', '178.79.169.132']));
+        $resolver->resolveAll('igor.io')->then($this->expectCallableOnceWith(array('178.79.169.131', '178.79.169.132')));
     }
 
     private function createExecutorMock()

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -122,6 +122,28 @@ class ResolverTest extends TestCase
         $resolver->resolve('igor.io')->then($this->expectCallableNever(), $errback);
     }
 
+    /** @test */
+    public function resolveAllShouldReturnAllAddresses()
+    {
+        $executor = $this->createExecutorMock();
+        $executor
+            ->expects($this->once())
+            ->method('query')
+            ->with($this->anything(), $this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($nameserver, $query) {
+                $response = new Message();
+                $response->header->set('qr', 1);
+                $response->questions[] = new Record($query->name, $query->type, $query->class);
+                $response->answers[] = new Record($query->name, $query->type, $query->class, 3600, '178.79.169.131');
+                $response->answers[] = new Record($query->name, $query->type, $query->class, 3600, '178.79.169.132');
+
+                return Promise\resolve($response);
+            }));
+
+        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver->resolveAll('igor.io')->then($this->expectCallableOnceWith(['178.79.169.131', '178.79.169.132']));
+    }
+
     private function createExecutorMock()
     {
         return $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();


### PR DESCRIPTION
The status quo with the resolver is that `resolve` will always return one `IP` address when resolving a hostname, even when the query response yields more. This proposed `resolveAll` method will return all addresses yielded from the query response.