### PR TITLE
Fix HHVM build for now again and ignore future HHVM build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ php:
   - 5.5
   - 5.6
   - 7
-  - hhvm
 
+# also test against HHVM, but require "trusty" and ignore errors
 matrix:
+  include:
+    - php: hhvm
+      dist: trusty
   allow_failures:
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ php:
   - 7
   - hhvm
 
+matrix:
+  allow_failures:
+    - php: hhvm
+
 sudo: false
 
 install:


### PR DESCRIPTION
Currently HHVM is failing, this PR allows HHVM to fail on Travis without failing the whole build