### PR TITLE
Lock minimum dependencies and work around circular dependency for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 sudo: false
 
 install:
-  - composer install --no-interaction
-  
+  - COMPOSER_ROOT_VERSION=`git describe --abbrev=0` composer install --no-interaction
+
 script:
   - vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -108,10 +108,12 @@ More details about version upgrades can be found in the [CHANGELOG](CHANGELOG.md
 ## Tests
 
 To run the test suite, you first need to clone this repo and then install all
-dependencies [through Composer](http://getcomposer.org):
+dependencies [through Composer](http://getcomposer.org).
+Because the test suite contains some circular dependencies, you may have to
+manually specify the root package version like this:
 
 ```bash
-$ composer install
+$ COMPOSER_ROOT_VERSION=`git describe --abbrev=0` composer install
 ```
 
 To run the test suite, go to the project root and run:

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
         "php": ">=5.3.0",
         "react/cache": "~0.4.0|~0.3.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
+        "react/promise": "^2.1 || ^1.2.1",
+        "react/promise-timer": "^1.2",
         "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5 || ^0.4.4",
-        "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.5",
-        "react/promise": "~2.1|~1.2",
-        "react/promise-timer": "~1.1"
+        "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^4.8.10"

--- a/tests/Query/TimeoutExecutorTest.php
+++ b/tests/Query/TimeoutExecutorTest.php
@@ -76,7 +76,7 @@ class TimeoutExecutorTest extends TestCase
 
     public function testWrappedWillBeCancelledOnTimeout()
     {
-        $this->executor = new TimeoutExecutor($this->wrapped, 0.001, $this->loop);
+        $this->executor = new TimeoutExecutor($this->wrapped, 0, $this->loop);
 
         $cancelled = 0;
 


### PR DESCRIPTION
The react/dns package currently has a dependency on react/socket and thus has no way of knowing which version of said package is compatible with this root package version. Here's a dependency graph that shows this cyclic dependency (generated via https://github.com/clue/graph-composer):

![orig](https://user-images.githubusercontent.com/776829/29092367-660a7fd8-7c86-11e7-95b0-7aaef179e540.png)

The dependency graph highlights how Composer picks an older version of react/socket by default which does not have this dependency. Once you actively pass the root package version, Composer will actually pick the "right" version:

![proper](https://user-images.githubusercontent.com/776829/29092368-6626922c-7c86-11e7-9d38-4421769ba7b3.png)

Note that this only affects this package when it's installed as the root package (for testing and development). Everything works without this when it's used as a normal dependency.

Refs https://github.com/reactphp/socket/pull/54
Builds on top of #70.