### PR TITLE
Remove broken TCP code, do not retry with invalid TCP query

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.5"
     },
     "require-dev": {
+        "clue/block-react": "^1.2",
         "phpunit/phpunit": "^5.0 || ^4.8.10"
     },
     "autoload": {


### PR DESCRIPTION
This PR simply removes all code related to TCP querying, because it is currently broken beyond repair, see #11 for more details. In other words: This actually improves query performance because we no longer time out after sending invalid protocol messages.

These changes are not a BC break because the public interfaces have been kept as-is.

This is the base for future TCP fixes that are discussed in #19 and due for the next major release :+1: 

Builds on top of #72
Closes #11