### PR TITLE
Work around DNS timeout issues for Windows users

### DIFF
--- a/tests/Query/ExecutorTest.php
+++ b/tests/Query/ExecutorTest.php
@@ -149,7 +149,7 @@ class ExecutorTest extends TestCase
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
         $promise = $this->executor->query('8.8.8.8:53', $query);
 
-        $this->setExpectedException('RuntimeException', 'DNS query for igor.io failed: Unable to connect to DNS server: Nope');
+        $this->setExpectedException('RuntimeException', 'DNS query for igor.io failed: Nope');
         Block\await($promise, $this->loop);
     }
 


### PR DESCRIPTION
Certain PHP versions on Windows require to read the full incoming receive buffer. This is actually a bug in PHP for Windows only that was fixed with PHP 7.0.17 and PHP 7.1.3.

This PR re-introduces the work-around that already landed with #53 but was later disabled by updating the socket version with #61. This temporary work-around works for all versions across all platforms, so it doesn't really hurt. Ultimately, this will be resolved once #12 lands in the next major version.

See also https://bugs.php.net/bug.php?id=74090 and php/php-src@89a5bd6.
Builds on top of #73
Resolves / closes #63