### PR TITLE
Support resolving from default hosts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ easily be used to create a DNS server.
 * [Caching](#caching)
   * [Custom cache adapter](#custom-cache-adapter)
 * [Advanced usage](#advanced-usage)
+  * [HostsFileExecutor](#hostsfileexecutor)
 * [Install](#install)
 * [Tests](#tests)
 * [License](#license)
@@ -117,6 +118,24 @@ $loop->run();
 ```
 
 See also the [fourth example](examples).
+
+### HostsFileExecutor
+
+Note that the above `Executor` class always performs an actual DNS query.
+If you also want to take entries from your hosts file into account, you may
+use this code:
+
+```php
+$hosts = \React\Dns\Config\HostsFile::loadFromPathBlocking();
+
+$executor = new Executor($loop, new Parser(), new BinaryDumper(), null);
+$executor = new HostsFileExecutor($hosts, $executor);
+
+$executor->query(
+    '8.8.8.8:53', 
+    new Query('localhost', Message::TYPE_A, Message::CLASS_IN, time())
+);
+```
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ $loop->run();
 
 See also the [first example](examples).
 
+> Note that the factory loads the hosts file from the filesystem once when
+  creating the resolver instance.
+  Ideally, this method should thus be executed only once before the loop starts
+  and not repeatedly while it is running.
+
 Pending DNS queries can be cancelled by cancelling its pending promise like so:
 
 ```php

--- a/src/Config/HostsFile.php
+++ b/src/Config/HostsFile.php
@@ -107,4 +107,29 @@ class HostsFile
 
         return $ips;
     }
+
+    /**
+     * Returns all hostnames for the given IPv4 or IPv6 address
+     *
+     * @param string $ip
+     * @return string[]
+     */
+    public function getHostsForIp($ip)
+    {
+        // check binary representation of IP to avoid string case and short notation
+        $ip = @inet_pton($ip);
+
+        $names = array();
+        foreach (preg_split('/\r?\n/', $this->contents) as $line) {
+            $parts = preg_split('/\s+/', $line);
+
+            if (inet_pton(array_shift($parts)) === $ip) {
+                foreach ($parts as $part) {
+                    $names[] = $part;
+                }
+            }
+        }
+
+        return $names;
+    }
 }

--- a/src/Config/HostsFile.php
+++ b/src/Config/HostsFile.php
@@ -12,7 +12,9 @@ use RuntimeException;
  *
  * Most notably, this file usually contains an entry to map "localhost" to the
  * local IP. Windows is a notable exception here, as Windows does not actually
- * include "localhost" in this file by default.
+ * include "localhost" in this file by default. To compensate for this, this
+ * class may explicitly be wrapped in another HostsFile instance which
+ * hard-codes these entries for Windows (see also Factory).
  *
  * This class mostly exists to abstract the parsing/extraction process so this
  * can be replaced with a faster alternative in the future.

--- a/src/Config/HostsFile.php
+++ b/src/Config/HostsFile.php
@@ -101,6 +101,11 @@ class HostsFile
             $parts = preg_split('/\s+/', $line);
             $ip = array_shift($parts);
             if ($parts && array_search($name, $parts) !== false) {
+                // remove IPv6 zone ID (`fe80::1%lo0` => `fe80:1`)
+                if (strpos($ip, ':') !== false && ($pos = strpos($ip, '%')) !== false) {
+                    $ip= substr($ip, 0, $pos);
+                }
+
                 $ips[] = $ip;
             }
         }
@@ -122,8 +127,14 @@ class HostsFile
         $names = array();
         foreach (preg_split('/\r?\n/', $this->contents) as $line) {
             $parts = preg_split('/\s+/', $line);
+            $addr = array_shift($parts);
 
-            if (inet_pton(array_shift($parts)) === $ip) {
+            // remove IPv6 zone ID (`fe80::1%lo0` => `fe80:1`)
+            if (strpos($addr, ':') !== false && ($pos = strpos($addr, '%')) !== false) {
+                $addr = substr($addr, 0, $pos);
+            }
+
+            if (@inet_pton($addr) === $ip) {
                 foreach ($parts as $part) {
                     $names[] = $part;
                 }

--- a/src/Config/HostsFile.php
+++ b/src/Config/HostsFile.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace React\Dns\Config;
+
+use RuntimeException;
+
+/**
+ * Represents a static hosts file which maps hostnames to IPs
+ *
+ * Hosts files are used on most systems to avoid actually hitting the DNS for
+ * certain common hostnames.
+ *
+ * Most notably, this file usually contains an entry to map "localhost" to the
+ * local IP. Windows is a notable exception here, as Windows does not actually
+ * include "localhost" in this file by default.
+ *
+ * This class mostly exists to abstract the parsing/extraction process so this
+ * can be replaced with a faster alternative in the future.
+ */
+class HostsFile
+{
+    /**
+     * Returns the default path for the hosts file on this system
+     *
+     * @return string
+     * @codeCoverageIgnore
+     */
+    public static function getDefaultPath()
+    {
+        // use static path for all Unix-based systems
+        if (DIRECTORY_SEPARATOR !== '\\') {
+            return '/etc/hosts';
+        }
+
+        // Windows actually stores the path in the registry under
+        // \HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\DataBasePath
+        $path = '%SystemRoot%\\system32\drivers\etc\hosts';
+
+        $base = getenv('SystemRoot');
+        if ($base === false) {
+            $base = 'C:\\Windows';
+        }
+
+        return str_replace('%SystemRoot%', $base, $path);
+    }
+
+    /**
+     * Loads a hosts file (from the given path or default location)
+     *
+     * Note that this method blocks while loading the given path and should
+     * thus be used with care! While this should be relatively fast for normal
+     * hosts file, this may be an issue if this file is located on a slow device
+     * or contains an excessive number of entries. In particular, this method
+     * should only be executed before the loop starts, not while it is running.
+     *
+     * @param ?string $path (optional) path to hosts file or null=load default location
+     * @return self
+     * @throws RuntimeException if the path can not be loaded (does not exist)
+     */
+    public static function loadFromPathBlocking($path = null)
+    {
+        if ($path === null) {
+            $path = self::getDefaultPath();
+        }
+
+        $contents = @file_get_contents($path);
+        if ($contents === false) {
+            throw new RuntimeException('Unable to load hosts file "' . $path . '"');
+        }
+
+        return new self($contents);
+    }
+
+    /**
+     * Instantiate new hosts file with the given hosts file contents
+     *
+     * @param string $contents
+     */
+    public function __construct($contents)
+    {
+        // remove all comments from the contents
+        $contents = preg_replace('/ *#.*/', '', strtolower($contents));
+
+        $this->contents = $contents;
+    }
+
+    /**
+     * Returns all IPs for the given hostname
+     *
+     * @param string $name
+     * @return string[]
+     */
+    public function getIpsForHost($name)
+    {
+        $name = strtolower($name);
+
+        $ips = array();
+        foreach (preg_split('/\r?\n/', $this->contents) as $line) {
+            $parts = preg_split('/\s+/', $line);
+            $ip = array_shift($parts);
+            if ($parts && array_search($name, $parts) !== false) {
+                $ips[] = $ip;
+            }
+        }
+
+        return $ips;
+    }
+}

--- a/src/Query/HostsFileExecutor.php
+++ b/src/Query/HostsFileExecutor.php
@@ -76,7 +76,7 @@ class HostsFileExecutor implements ExecutorInterface
             return inet_ntop(strrev($ip));
         } elseif (substr($host, -9) === '.ip6.arpa') {
             // IPv6: replace dots, reverse nibbles and interpret as hexadecimal string
-            $ip = @inet_ntop(hex2bin(strrev(str_replace('.', '', substr($host, 0, -9)))));
+            $ip = @inet_ntop(pack('H*', strrev(str_replace('.', '', substr($host, 0, -9)))));
             if ($ip === false) {
                 return null;
             }

--- a/src/Query/HostsFileExecutor.php
+++ b/src/Query/HostsFileExecutor.php
@@ -28,6 +28,7 @@ class HostsFileExecutor implements ExecutorInterface
     public function query($nameserver, Query $query)
     {
         if ($query->class === Message::CLASS_IN && ($query->type === Message::TYPE_A || $query->type === Message::TYPE_AAAA)) {
+            // forward lookup for type A or AAAA
             $records = array();
             $expectsColon = $query->type === Message::TYPE_AAAA;
             foreach ($this->hosts->getIpsForHost($query->name) as $ip) {
@@ -42,8 +43,47 @@ class HostsFileExecutor implements ExecutorInterface
                     Message::createResponseWithAnswersForQuery($query, $records)
                 );
             }
+        } elseif ($query->class === Message::CLASS_IN && $query->type === Message::TYPE_PTR) {
+            // reverse lookup: extract IPv4 or IPv6 from special `.arpa` domain
+            $ip = $this->getIpFromHost($query->name);
+
+            if ($ip !== null) {
+                $records = array();
+                foreach ($this->hosts->getHostsForIp($ip) as $host) {
+                    $records[] = new Record($query->name, $query->type, $query->class, 0, $host);
+                }
+
+                if ($records) {
+                    return Promise\resolve(
+                        Message::createResponseWithAnswersForQuery($query, $records)
+                    );
+                }
+            }
         }
 
         return $this->fallback->query($nameserver, $query);
+    }
+
+    private function getIpFromHost($host)
+    {
+        if (substr($host, -13) === '.in-addr.arpa') {
+            // IPv4: read as IP and reverse bytes
+            $ip = @inet_pton(substr($host, 0, -13));
+            if ($ip === false || isset($ip[4])) {
+                return null;
+            }
+
+            return inet_ntop(strrev($ip));
+        } elseif (substr($host, -9) === '.ip6.arpa') {
+            // IPv6: replace dots, reverse nibbles and interpret as hexadecimal string
+            $ip = @inet_ntop(hex2bin(strrev(str_replace('.', '', substr($host, 0, -9)))));
+            if ($ip === false) {
+                return null;
+            }
+
+            return $ip;
+        } else {
+            return null;
+        }
     }
 }

--- a/src/Query/HostsFileExecutor.php
+++ b/src/Query/HostsFileExecutor.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace React\Dns\Query;
+
+use React\Dns\Config\HostsFile;
+use React\Dns\Model\Message;
+use React\Dns\Model\Record;
+use React\Promise;
+
+/**
+ * Resolves hosts from the givne HostsFile or falls back to another executor
+ *
+ * If the host is found in the hosts file, it will not be passed to the actual
+ * DNS executor. If the host is not found in the hosts file, it will be passed
+ * to the DNS executor as a fallback.
+ */
+class HostsFileExecutor implements ExecutorInterface
+{
+    private $hosts;
+    private $fallback;
+
+    public function __construct(HostsFile $hosts, ExecutorInterface $fallback)
+    {
+        $this->hosts = $hosts;
+        $this->fallback = $fallback;
+    }
+
+    public function query($nameserver, Query $query)
+    {
+        if ($query->class === Message::CLASS_IN && $query->type === Message::TYPE_A) {
+            $ips = $this->hosts->getIpsForHost($query->name);
+            if ($ips) {
+                $records = array();
+                foreach ($ips as $ip) {
+                    $records[] = new Record($query->name, $query->type, $query->class, 0, $ip);
+                }
+
+                return Promise\resolve(
+                    Message::createResponseWithAnswersForQuery($query, $records)
+                );
+            }
+        }
+
+        return $this->fallback->query($nameserver, $query);
+    }
+}

--- a/src/Query/HostsFileExecutor.php
+++ b/src/Query/HostsFileExecutor.php
@@ -27,11 +27,12 @@ class HostsFileExecutor implements ExecutorInterface
 
     public function query($nameserver, Query $query)
     {
-        if ($query->class === Message::CLASS_IN && $query->type === Message::TYPE_A) {
+        if ($query->class === Message::CLASS_IN && ($query->type === Message::TYPE_A || $query->type === Message::TYPE_AAAA)) {
             $records = array();
+            $expectsColon = $query->type === Message::TYPE_AAAA;
             foreach ($this->hosts->getIpsForHost($query->name) as $ip) {
-                // ensure this is an IPv4 address
-                if (strpos($ip, ':') === false) {
+                // ensure this is an IPv4/IPV6 address according to query type
+                if ((strpos($ip, ':') !== false) === $expectsColon) {
                     $records[] = new Record($query->name, $query->type, $query->class, 0, $ip);
                 }
             }

--- a/src/Query/HostsFileExecutor.php
+++ b/src/Query/HostsFileExecutor.php
@@ -28,13 +28,15 @@ class HostsFileExecutor implements ExecutorInterface
     public function query($nameserver, Query $query)
     {
         if ($query->class === Message::CLASS_IN && $query->type === Message::TYPE_A) {
-            $ips = $this->hosts->getIpsForHost($query->name);
-            if ($ips) {
-                $records = array();
-                foreach ($ips as $ip) {
+            $records = array();
+            foreach ($this->hosts->getIpsForHost($query->name) as $ip) {
+                // ensure this is an IPv4 address
+                if (strpos($ip, ':') === false) {
                     $records[] = new Record($query->name, $query->type, $query->class, 0, $ip);
                 }
+            }
 
+            if ($records) {
                 return Promise\resolve(
                     Message::createResponseWithAnswersForQuery($query, $records)
                 );

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -60,7 +60,7 @@ class Factory
         // To compensate for this, we explicitly use hard-coded defaults for localhost
         if (DIRECTORY_SEPARATOR === '\\') {
             $executor = new HostsFileExecutor(
-                new HostsFile("127.0.0.1 localhost"),
+                new HostsFile("127.0.0.1 localhost\n::1 localhost"),
                 $executor
             );
         }

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -4,21 +4,24 @@ namespace React\Dns\Resolver;
 
 use React\Cache\ArrayCache;
 use React\Cache\CacheInterface;
-use React\Dns\Query\Executor;
-use React\Dns\Query\CachedExecutor;
-use React\Dns\Query\RecordCache;
+use React\Dns\Config\HostsFile;
 use React\Dns\Protocol\Parser;
 use React\Dns\Protocol\BinaryDumper;
-use React\EventLoop\LoopInterface;
+use React\Dns\Query\CachedExecutor;
+use React\Dns\Query\Executor;
+use React\Dns\Query\ExecutorInterface;
+use React\Dns\Query\HostsFileExecutor;
+use React\Dns\Query\RecordCache;
 use React\Dns\Query\RetryExecutor;
 use React\Dns\Query\TimeoutExecutor;
+use React\EventLoop\LoopInterface;
 
 class Factory
 {
     public function create($nameserver, LoopInterface $loop)
     {
         $nameserver = $this->addPortToServerIfMissing($nameserver);
-        $executor = $this->createRetryExecutor($loop);
+        $executor = $this->decorateHostsFileExecutor($this->createRetryExecutor($loop));
 
         return new Resolver($nameserver, $executor);
     }
@@ -30,9 +33,28 @@ class Factory
         }
 
         $nameserver = $this->addPortToServerIfMissing($nameserver);
-        $executor = $this->createCachedExecutor($loop, $cache);
+        $executor = $this->decorateHostsFileExecutor($this->createCachedExecutor($loop, $cache));
 
         return new Resolver($nameserver, $executor);
+    }
+
+    /**
+     * Tries to load the hosts file and decorates the given executor on success
+     *
+     * @param ExecutorInterface $executor
+     * @return ExecutorInterface
+     * @codeCoverageIgnore
+     */
+    private function decorateHostsFileExecutor(ExecutorInterface $executor)
+    {
+        try {
+            $hosts = HostsFile::loadFromPathBlocking();
+        } catch (\RuntimeException $e) {
+            // ignore this file if it can not be loaded
+            return $executor;
+        }
+
+        return new HostsFileExecutor($hosts, $executor);
     }
 
     protected function createExecutor(LoopInterface $loop)

--- a/tests/Config/HostsFileTest.php
+++ b/tests/Config/HostsFileTest.php
@@ -41,6 +41,13 @@ class HostsFileTest extends TestCase
         $this->assertEquals(array(), $hosts->getIpsForHost('example.com'));
     }
 
+    public function testIgnoresIpv6ZoneId()
+    {
+        $hosts = new HostsFile('fe80::1%lo0 localhost');
+
+        $this->assertEquals(array('fe80::1'), $hosts->getIpsForHost('localhost'));
+    }
+
     public function testSkipsComments()
     {
         $hosts = new HostsFile('# start' . PHP_EOL .'#127.0.0.1 localhost' . PHP_EOL . '127.0.0.2 localhost # example.com');
@@ -113,6 +120,13 @@ class HostsFileTest extends TestCase
         $hosts = new HostsFile('FE80::00a1 localhost');
 
         $this->assertEquals(array('localhost'), $hosts->getHostsForIp('fe80::A1'));
+    }
+
+    public function testReverseLookupIgnoresIpv6ZoneId()
+    {
+        $hosts = new HostsFile('fe80::1%lo0 localhost');
+
+        $this->assertEquals(array('localhost'), $hosts->getHostsForIp('fe80::1'));
     }
 
     public function testReverseLookupReturnsMultipleHostsOverSingleLine()

--- a/tests/Config/HostsFileTest.php
+++ b/tests/Config/HostsFileTest.php
@@ -84,4 +84,48 @@ class HostsFileTest extends TestCase
 
         $this->assertEquals(array('127.0.0.1', '::1'), $hosts->getIpsForHost('localhost'));
     }
+
+    public function testReverseLookup()
+    {
+        $hosts = new HostsFile('127.0.0.1 localhost');
+
+        $this->assertEquals(array('localhost'), $hosts->getHostsForIp('127.0.0.1'));
+        $this->assertEquals(array(), $hosts->getHostsForIp('192.168.1.1'));
+    }
+
+    public function testReverseNonIpReturnsNothing()
+    {
+        $hosts = new HostsFile('127.0.0.1 localhost');
+
+        $this->assertEquals(array(), $hosts->getHostsForIp('localhost'));
+        $this->assertEquals(array(), $hosts->getHostsForIp('127.0.0.1.1'));
+    }
+
+    public function testReverseLookupReturnsLowerCaseHost()
+    {
+        $hosts = new HostsFile('127.0.0.1 LocalHost');
+
+        $this->assertEquals(array('localhost'), $hosts->getHostsForIp('127.0.0.1'));
+    }
+
+    public function testReverseLookupChecksNormalizedIpv6()
+    {
+        $hosts = new HostsFile('FE80::00a1 localhost');
+
+        $this->assertEquals(array('localhost'), $hosts->getHostsForIp('fe80::A1'));
+    }
+
+    public function testReverseLookupReturnsMultipleHostsOverSingleLine()
+    {
+        $hosts = new HostsFile("::1 ip6-localhost ip6-loopback");
+
+        $this->assertEquals(array('ip6-localhost', 'ip6-loopback'), $hosts->getHostsForIp('::1'));
+    }
+
+    public function testReverseLookupReturnsMultipleHostsOverMultipleLines()
+    {
+        $hosts = new HostsFile("::1 ip6-localhost\n::1 ip6-loopback");
+
+        $this->assertEquals(array('ip6-localhost', 'ip6-loopback'), $hosts->getHostsForIp('::1'));
+    }
 }

--- a/tests/Config/HostsFileTest.php
+++ b/tests/Config/HostsFileTest.php
@@ -77,4 +77,11 @@ class HostsFileTest extends TestCase
 
         $this->assertEquals(array('127.0.0.1', '127.0.0.2', '127.0.0.3', '127.0.0.4'), $hosts->getIpsForHost('localhost'));
     }
+
+    public function testMergesIpv4AndIpv6EntriesOverMultipleLines()
+    {
+        $hosts = new HostsFile("127.0.0.1 localhost\n::1 localhost");
+
+        $this->assertEquals(array('127.0.0.1', '::1'), $hosts->getIpsForHost('localhost'));
+    }
 }

--- a/tests/Config/HostsFileTest.php
+++ b/tests/Config/HostsFileTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace React\Tests\Dns\Config;
+
+use React\Tests\Dns\TestCase;
+use React\Dns\Config\HostsFile;
+
+class HostsFileTest extends TestCase
+{
+    public function testLoadsFromDefaultPath()
+    {
+        $hosts = HostsFile::loadFromPathBlocking();
+
+        $this->assertInstanceOf('React\Dns\Config\HostsFile', $hosts);
+    }
+
+    public function testDefaultShouldHaveLocalhostMapped()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Not supported on Windows');
+        }
+
+        $hosts = HostsFile::loadFromPathBlocking();
+
+        $this->assertContains('127.0.0.1', $hosts->getIpsForHost('localhost'));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testLoadThrowsForInvalidPath()
+    {
+        HostsFile::loadFromPathBlocking('does/not/exist');
+    }
+
+    public function testContainsSingleLocalhostEntry()
+    {
+        $hosts = new HostsFile('127.0.0.1 localhost');
+
+        $this->assertEquals(array('127.0.0.1'), $hosts->getIpsForHost('localhost'));
+        $this->assertEquals(array(), $hosts->getIpsForHost('example.com'));
+    }
+
+    public function testSkipsComments()
+    {
+        $hosts = new HostsFile('# start' . PHP_EOL .'#127.0.0.1 localhost' . PHP_EOL . '127.0.0.2 localhost # example.com');
+
+        $this->assertEquals(array('127.0.0.2'), $hosts->getIpsForHost('localhost'));
+        $this->assertEquals(array(), $hosts->getIpsForHost('example.com'));
+    }
+
+    public function testContainsSingleLocalhostEntryWithCaseIgnored()
+    {
+        $hosts = new HostsFile('127.0.0.1 LocalHost');
+
+        $this->assertEquals(array('127.0.0.1'), $hosts->getIpsForHost('LOCALHOST'));
+    }
+
+    public function testEmptyFileContainsNothing()
+    {
+        $hosts = new HostsFile('');
+
+        $this->assertEquals(array(), $hosts->getIpsForHost('example.com'));
+    }
+
+    public function testSingleEntryWithMultipleNames()
+    {
+        $hosts = new HostsFile('127.0.0.1 localhost example.com');
+
+        $this->assertEquals(array('127.0.0.1'), $hosts->getIpsForHost('example.com'));
+        $this->assertEquals(array('127.0.0.1'), $hosts->getIpsForHost('localhost'));
+    }
+
+    public function testMergesEntriesOverMultipleLines()
+    {
+        $hosts = new HostsFile("127.0.0.1 localhost\n127.0.0.2 localhost\n127.0.0.3 a localhost b\n127.0.0.4 a localhost");
+
+        $this->assertEquals(array('127.0.0.1', '127.0.0.2', '127.0.0.3', '127.0.0.4'), $hosts->getIpsForHost('localhost'));
+    }
+}

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -17,6 +17,18 @@ class FunctionalTest extends TestCase
         $this->resolver = $factory->create('8.8.8.8', $this->loop);
     }
 
+    public function testResolveLocalhostResolves()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Not supported on Windows');
+        }
+
+        $promise = $this->resolver->resolve('localhost');
+        $promise->then($this->expectCallableOnce(), $this->expectCallableNever());
+
+        $this->loop->run();
+    }
+
     public function testResolveGoogleResolves()
     {
         $promise = $this->resolver->resolve('google.com');

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -19,10 +19,6 @@ class FunctionalTest extends TestCase
 
     public function testResolveLocalhostResolves()
     {
-        if (DIRECTORY_SEPARATOR === '\\') {
-            $this->markTestSkipped('Not supported on Windows');
-        }
-
         $promise = $this->resolver->resolve('localhost');
         $promise->then($this->expectCallableOnce(), $this->expectCallableNever());
 

--- a/tests/Query/HostsFileExecutorTest.php
+++ b/tests/Query/HostsFileExecutorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace React\Tests\Dns\Query;
+
+use React\Tests\Dns\TestCase;
+use React\Dns\Query\HostsFileExecutor;
+use React\Dns\Query\Query;
+use React\Dns\Model\Message;
+
+class HostsFileExecutorTest extends TestCase
+{
+    private $hosts;
+    private $fallback;
+    private $executor;
+
+    public function setUp()
+    {
+        $this->hosts = $this->getMockBuilder('React\Dns\Config\HostsFile')->disableOriginalConstructor()->getMock();
+        $this->fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $this->executor = new HostsFileExecutor($this->hosts, $this->fallback);
+    }
+
+    public function testDoesNotTryToGetIpsForMxQuery()
+    {
+        $this->hosts->expects($this->never())->method('getIpsForHost');
+        $this->fallback->expects($this->once())->method('query');
+
+        $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_MX, Message::CLASS_IN, 0));
+    }
+
+    public function testFallsBackIfNoIpsWereFound()
+    {
+        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array());
+        $this->fallback->expects($this->once())->method('query');
+
+        $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_A, Message::CLASS_IN, 0));
+    }
+
+    public function testReturnsResponseMessageIfIpsWereFound()
+    {
+        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('127.0.0.1'));
+        $this->fallback->expects($this->never())->method('query');
+
+        $ret = $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_A, Message::CLASS_IN, 0));
+    }
+}

--- a/tests/Query/HostsFileExecutorTest.php
+++ b/tests/Query/HostsFileExecutorTest.php
@@ -108,11 +108,19 @@ class HostsFileExecutorTest extends TestCase
         $this->executor->query('8.8.8.8', new Query('::1.in-addr.arpa', Message::TYPE_PTR, Message::CLASS_IN, 0));
     }
 
-    public function testReverseFallsBackForInvalidIpv6Address()
+    public function testReverseFallsBackForInvalidLengthIpv6Address()
     {
         $this->hosts->expects($this->never())->method('getHostsForIp');
         $this->fallback->expects($this->once())->method('query');
 
         $this->executor->query('8.8.8.8', new Query('abcd.ip6.arpa', Message::TYPE_PTR, Message::CLASS_IN, 0));
+    }
+
+    public function testReverseFallsBackForInvalidHexIpv6Address()
+    {
+        $this->hosts->expects($this->never())->method('getHostsForIp');
+        $this->fallback->expects($this->once())->method('query');
+
+        $this->executor->query('8.8.8.8', new Query('zZz.ip6.arpa', Message::TYPE_PTR, Message::CLASS_IN, 0));
     }
 }

--- a/tests/Query/HostsFileExecutorTest.php
+++ b/tests/Query/HostsFileExecutorTest.php
@@ -51,4 +51,20 @@ class HostsFileExecutorTest extends TestCase
 
         $ret = $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_A, Message::CLASS_IN, 0));
     }
+
+    public function testReturnsResponseMessageIfIpv6AddressesWereFound()
+    {
+        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('::1'));
+        $this->fallback->expects($this->never())->method('query');
+
+        $ret = $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_AAAA, Message::CLASS_IN, 0));
+    }
+
+    public function testFallsBackIfNoIpv6Matches()
+    {
+        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('127.0.0.1'));
+        $this->fallback->expects($this->once())->method('query');
+
+        $ret = $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_AAAA, Message::CLASS_IN, 0));
+    }
 }

--- a/tests/Query/HostsFileExecutorTest.php
+++ b/tests/Query/HostsFileExecutorTest.php
@@ -43,4 +43,12 @@ class HostsFileExecutorTest extends TestCase
 
         $ret = $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_A, Message::CLASS_IN, 0));
     }
+
+    public function testFallsBackIfNoIpv4Matches()
+    {
+        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('::1'));
+        $this->fallback->expects($this->once())->method('query');
+
+        $ret = $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_A, Message::CLASS_IN, 0));
+    }
 }

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -97,7 +97,8 @@ class FactoryTest extends TestCase
     {
         $executor = $this->getResolverPrivateMemberValue($resolver, 'executor');
 
-        if ($executor instanceof HostsFileExecutor) {
+        // extract underlying executor that may be wrapped in multiple layers of hosts file executors
+        while ($executor instanceof HostsFileExecutor) {
             $reflector = new \ReflectionProperty('React\Dns\Query\HostsFileExecutor', 'fallback');
             $reflector->setAccessible(true);
 

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -4,6 +4,7 @@ namespace React\Tests\Dns\Resolver;
 
 use React\Dns\Resolver\Factory;
 use React\Tests\Dns\TestCase;
+use React\Dns\Query\HostsFileExecutor;
 
 class FactoryTest extends TestCase
 {
@@ -39,7 +40,7 @@ class FactoryTest extends TestCase
         $resolver = $factory->createCached('8.8.8.8:53', $loop);
 
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
-        $executor = $this->getResolverPrivateMemberValue($resolver, 'executor');
+        $executor = $this->getResolverPrivateExecutor($resolver);
         $this->assertInstanceOf('React\Dns\Query\CachedExecutor', $executor);
         $recordCache = $this->getCachedExecutorPrivateMemberValue($executor, 'cache');
         $recordCacheCache = $this->getRecordCachePrivateMemberValue($recordCache, 'cache');
@@ -57,7 +58,7 @@ class FactoryTest extends TestCase
         $resolver = $factory->createCached('8.8.8.8:53', $loop, $cache);
 
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
-        $executor = $this->getResolverPrivateMemberValue($resolver, 'executor');
+        $executor = $this->getResolverPrivateExecutor($resolver);
         $this->assertInstanceOf('React\Dns\Query\CachedExecutor', $executor);
         $recordCache = $this->getCachedExecutorPrivateMemberValue($executor, 'cache');
         $recordCacheCache = $this->getRecordCachePrivateMemberValue($recordCache, 'cache');
@@ -90,6 +91,20 @@ class FactoryTest extends TestCase
             array('::1',            '[::1]:53'),
             array('[::1]:53',       '[::1]:53')
         );
+    }
+
+    private function getResolverPrivateExecutor($resolver)
+    {
+        $executor = $this->getResolverPrivateMemberValue($resolver, 'executor');
+
+        if ($executor instanceof HostsFileExecutor) {
+            $reflector = new \ReflectionProperty('React\Dns\Query\HostsFileExecutor', 'fallback');
+            $reflector->setAccessible(true);
+
+            $executor = $reflector->getValue($executor);
+        }
+
+        return $executor;
     }
 
     private function getResolverPrivateMemberValue($resolver, $field)


### PR DESCRIPTION
TL;DR: Once this is in, you can now create connections to `localhost` as expected across all platforms (https://github.com/reactphp/socket/issues/88).

This PR adds support for resolving hosts from the system default hosts file. This file is often used for static mappings of certain common hostnames, such as `localhost`.

The hosts file will be loaded once the `Factory` creates the `Resolver` instance. The hosts file is loaded on Unix and Windows based systems alike and if this fails, this will simply be ignored and thus preserves the existing behavior. Windows does not store "localhost" in the hosts file by default, but resolves this internally. This PR also adds static mapping for this, so that the DNS resolver now behaves more like the system resolver.

The hosts file will be preferred for type `A` (IPv4), `AAAA` (IPv6) and `PTR` (reverse DNS) requests. For any other type or if no match is found, it will fall back to the default executor so that this does not affect the existing behavior.

I know this is a pretty big PR, but I've tried to keep the individual commits so reviewing individual changesets may be easier.

Closes #10
Refs https://github.com/reactphp/socket/issues/88