### PR TITLE
Move react/socket to dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.5"
     },
     "require-dev": {
-        "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5 || ^0.4.4",
+        "react/socket": "^1.0 || ^0.8",
         "clue/block-react": "^1.2",
         "phpunit/phpunit": "^5.0 || ^4.8.10"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
         "react/promise": "^2.1 || ^1.2.1",
         "react/promise-timer": "^1.2",
-        "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5 || ^0.4.4",
         "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.5"
     },
     "require-dev": {
+        "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5 || ^0.4.4",
         "clue/block-react": "^1.2",
         "phpunit/phpunit": "^5.0 || ^4.8.10"
     },


### PR DESCRIPTION
To reduce cyclic dependency between the two, as it is only used in tests