### PR TITLE
Forward compatibility with PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^5.0 || ^4.8.10"
+        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": { "React\\Dns\\": "src" }

--- a/tests/Config/FilesystemFactoryTest.php
+++ b/tests/Config/FilesystemFactoryTest.php
@@ -2,9 +2,10 @@
 
 namespace React\Test\Dns\Config;
 
+use PHPUnit\Framework\TestCase;
 use React\Dns\Config\FilesystemFactory;
 
-class FilesystemFactoryTest extends \PHPUnit_Framework_TestCase
+class FilesystemFactoryTest extends TestCase
 {
     /** @test */
     public function parseEtcResolvConfShouldParseCorrectly()

--- a/tests/Model/MessageTest.php
+++ b/tests/Model/MessageTest.php
@@ -2,10 +2,11 @@
 
 namespace React\Tests\Dns\Model;
 
+use PHPUnit\Framework\TestCase;
 use React\Dns\Query\Query;
 use React\Dns\Model\Message;
 
-class MessageTest extends \PHPUnit_Framework_TestCase
+class MessageTest extends TestCase
 {
     public function testCreateRequestDesiresRecusion()
     {

--- a/tests/Protocol/BinaryDumperTest.php
+++ b/tests/Protocol/BinaryDumperTest.php
@@ -2,10 +2,11 @@
 
 namespace React\Tests\Dns\Protocol;
 
+use PHPUnit\Framework\TestCase;
 use React\Dns\Protocol\BinaryDumper;
 use React\Dns\Model\Message;
 
-class BinaryDumperTest extends \PHPUnit_Framework_TestCase
+class BinaryDumperTest extends TestCase
 {
     public function testRequestToBinary()
     {

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -2,10 +2,11 @@
 
 namespace React\Tests\Dns\Protocol;
 
+use PHPUnit\Framework\TestCase;
 use React\Dns\Protocol\Parser;
 use React\Dns\Model\Message;
 
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Query/ExecutorTest.php
+++ b/tests/Query/ExecutorTest.php
@@ -46,17 +46,24 @@ class ExecutorTest extends TestCase
         $this->executor->query('8.8.8.8:53', $query);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @expectedException RuntimeException
+     */
     public function resolveShouldRejectIfRequestIsLargerThan512Bytes()
     {
         $query = new Query(str_repeat('a', 512).'.igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
         $promise = $this->executor->query('8.8.8.8:53', $query);
 
-        $this->setExpectedException('RuntimeException', 'DNS query for ' . $query->name . ' failed: Requested transport "tcp" not available, only UDP is supported in this version');
+        $this->expectExceptionMessage('DNS query for ' . $query->name . ' failed: Requested transport "tcp" not available, only UDP is supported in this version');
         Block\await($promise, $this->loop);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @expectedException React\Dns\Query\CancellationException
+     * @expectedExceptionMessage DNS query for igor.io has been cancelled
+     */
     public function resolveShouldCloseConnectionWhenCancelled()
     {
         $conn = $this->createConnectionMock(false);
@@ -80,11 +87,14 @@ class ExecutorTest extends TestCase
 
         $promise->cancel();
 
-        $this->setExpectedException('React\Dns\Query\CancellationException', 'DNS query for igor.io has been cancelled');
         Block\await($promise, $this->loop);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @expectedException React\Dns\Query\CancellationException
+     * @expectedExceptionMessage DNS query for igor.io has been cancelled
+     */
     public function resolveShouldNotStartOrCancelTimerWhenCancelledWithTimeoutIsNull()
     {
         $this->loop
@@ -98,7 +108,6 @@ class ExecutorTest extends TestCase
 
         $promise->cancel();
 
-        $this->setExpectedException('React\Dns\Query\CancellationException', 'DNS query for igor.io has been cancelled');
         Block\await($promise, $this->loop);
     }
 
@@ -128,7 +137,11 @@ class ExecutorTest extends TestCase
         $this->executor->query('8.8.8.8:53', $query);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage DNS query for igor.io failed: Nope
+     */
     public function resolveShouldFailIfUdpThrow()
     {
         $this->loop
@@ -149,7 +162,6 @@ class ExecutorTest extends TestCase
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
         $promise = $this->executor->query('8.8.8.8:53', $query);
 
-        $this->setExpectedException('RuntimeException', 'DNS query for igor.io failed: Nope');
         Block\await($promise, $this->loop);
     }
 
@@ -188,7 +200,11 @@ class ExecutorTest extends TestCase
         $this->executor->query('8.8.8.8:53', $query);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @expectedException React\Dns\Query\TimeoutException
+     * @expectedExceptionMessage DNS query for igor.io timed out
+     */
     public function resolveShouldCloseConnectionOnTimeout()
     {
         $this->executor = $this->createExecutorMock();
@@ -218,7 +234,6 @@ class ExecutorTest extends TestCase
         $this->assertNotNull($timerCallback);
         $timerCallback();
 
-        $this->setExpectedException('React\Dns\Query\TimeoutException', 'DNS query for igor.io timed out');
         Block\await($promise, $this->loop);
     }
 

--- a/tests/Query/ExecutorTest.php
+++ b/tests/Query/ExecutorTest.php
@@ -46,24 +46,17 @@ class ExecutorTest extends TestCase
         $this->executor->query('8.8.8.8:53', $query);
     }
 
-    /**
-     * @test
-     * @expectedException RuntimeException
-     */
+    /** @test */
     public function resolveShouldRejectIfRequestIsLargerThan512Bytes()
     {
         $query = new Query(str_repeat('a', 512).'.igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
         $promise = $this->executor->query('8.8.8.8:53', $query);
 
-        $this->expectExceptionMessage('DNS query for ' . $query->name . ' failed: Requested transport "tcp" not available, only UDP is supported in this version');
+        $this->setExpectedException('RuntimeException', 'DNS query for ' . $query->name . ' failed: Requested transport "tcp" not available, only UDP is supported in this version');
         Block\await($promise, $this->loop);
     }
 
-    /**
-     * @test
-     * @expectedException React\Dns\Query\CancellationException
-     * @expectedExceptionMessage DNS query for igor.io has been cancelled
-     */
+    /** @test */
     public function resolveShouldCloseConnectionWhenCancelled()
     {
         $conn = $this->createConnectionMock(false);
@@ -87,14 +80,11 @@ class ExecutorTest extends TestCase
 
         $promise->cancel();
 
+        $this->setExpectedException('React\Dns\Query\CancellationException', 'DNS query for igor.io has been cancelled');
         Block\await($promise, $this->loop);
     }
 
-    /**
-     * @test
-     * @expectedException React\Dns\Query\CancellationException
-     * @expectedExceptionMessage DNS query for igor.io has been cancelled
-     */
+    /** @test */
     public function resolveShouldNotStartOrCancelTimerWhenCancelledWithTimeoutIsNull()
     {
         $this->loop
@@ -108,6 +98,7 @@ class ExecutorTest extends TestCase
 
         $promise->cancel();
 
+        $this->setExpectedException('React\Dns\Query\CancellationException', 'DNS query for igor.io has been cancelled');
         Block\await($promise, $this->loop);
     }
 
@@ -137,11 +128,7 @@ class ExecutorTest extends TestCase
         $this->executor->query('8.8.8.8:53', $query);
     }
 
-    /**
-     * @test
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage DNS query for igor.io failed: Nope
-     */
+    /** @test */
     public function resolveShouldFailIfUdpThrow()
     {
         $this->loop
@@ -162,6 +149,7 @@ class ExecutorTest extends TestCase
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN, 1345656451);
         $promise = $this->executor->query('8.8.8.8:53', $query);
 
+        $this->setExpectedException('RuntimeException', 'DNS query for igor.io failed: Nope');
         Block\await($promise, $this->loop);
     }
 
@@ -200,11 +188,7 @@ class ExecutorTest extends TestCase
         $this->executor->query('8.8.8.8:53', $query);
     }
 
-    /**
-     * @test
-     * @expectedException React\Dns\Query\TimeoutException
-     * @expectedExceptionMessage DNS query for igor.io timed out
-     */
+    /** @test */
     public function resolveShouldCloseConnectionOnTimeout()
     {
         $this->executor = $this->createExecutorMock();
@@ -234,6 +218,7 @@ class ExecutorTest extends TestCase
         $this->assertNotNull($timerCallback);
         $timerCallback();
 
+        $this->setExpectedException('React\Dns\Query\TimeoutException', 'DNS query for igor.io timed out');
         Block\await($promise, $this->loop);
     }
 

--- a/tests/Query/RecordBagTest.php
+++ b/tests/Query/RecordBagTest.php
@@ -2,11 +2,12 @@
 
 namespace React\Tests\Dns\Query;
 
+use PHPUnit\Framework\TestCase;
 use React\Dns\Query\RecordBag;
 use React\Dns\Model\Message;
 use React\Dns\Model\Record;
 
-class RecordBagTest extends \PHPUnit_Framework_TestCase
+class RecordBagTest extends TestCase
 {
     /**
     * @covers React\Dns\Query\RecordBag

--- a/tests/Query/RecordCacheTest.php
+++ b/tests/Query/RecordCacheTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Dns\Query;
 
+use PHPUnit\Framework\TestCase;
 use React\Cache\ArrayCache;
 use React\Dns\Model\Message;
 use React\Dns\Model\Record;
@@ -9,7 +10,7 @@ use React\Dns\Query\RecordCache;
 use React\Dns\Query\Query;
 use React\Promise\PromiseInterface;
 
-class RecordCacheTest extends \PHPUnit_Framework_TestCase
+class RecordCacheTest extends TestCase
 {
     /**
     * @covers React\Dns\Query\RecordCache

--- a/tests/Resolver/ResolveAliasesTest.php
+++ b/tests/Resolver/ResolveAliasesTest.php
@@ -2,12 +2,13 @@
 
 namespace React\Tests\Dns\Resolver;
 
+use PHPUnit\Framework\TestCase;
 use React\Dns\Resolver\Resolver;
 use React\Dns\Query\Query;
 use React\Dns\Model\Message;
 use React\Dns\Model\Record;
 
-class ResolveAliasesTest extends \PHPUnit_Framework_TestCase
+class ResolveAliasesTest extends TestCase
 {
     /**
      * @covers React\Dns\Resolver\Resolver::resolveAliases

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,4 +41,21 @@ abstract class TestCase extends BaseTestCase
     {
         return $this->getMockBuilder('React\Tests\Dns\CallableStub')->getMock();
     }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+         if (method_exists($this, 'expectException')) {
+             // PHPUnit 5
+             $this->expectException($exception);
+             if ($exceptionMessage !== '') {
+                 $this->expectExceptionMessage($exceptionMessage);
+             }
+             if ($exceptionCode !== null) {
+                 $this->expectExceptionCode($exceptionCode);
+             }
+         } else {
+             // legacy PHPUnit 4
+             parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+         }
+     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,9 @@
 
 namespace React\Tests\Dns;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
 {
     protected function expectCallableOnce()
     {


### PR DESCRIPTION
As did in others Reactphp repos, I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This helped us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.

