### PR TITLE
Test against PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm # ignore errors, see below
 
 # lock distro so new future defaults will not break the build


### PR DESCRIPTION
With the release of [`PHP 7.2`](http://php.net/archive/2017.php#id2017-11-30-1), would be interesting to test it. I've also added `PHP 7.1` tests.