### PR TITLE
Add Config::loadSystemConfigBlocking() to load default system config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ names, baby!
 
 ```php
 $loop = React\EventLoop\Factory::create();
+
+$config = React\Dns\Config\Config::loadSystemConfigBlocking();
+$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+
 $factory = new React\Dns\Resolver\Factory();
-$dns = $factory->create('8.8.8.8', $loop);
+$dns = $factory->create($server, $loop);
 
 $dns->resolve('igor.io')->then(function ($ip) {
     echo "Host: $ip\n";
@@ -39,6 +43,14 @@ $loop->run();
 ```
 
 See also the [first example](examples).
+
+The `Config` class can be used to load the system default config. This is an
+operation that may access the filesystem and block. Ideally, this method should
+thus be executed only once before the loop starts and not repeatedly while it is
+running.
+Note that this class may return an *empty* configuration if the system config
+can not be loaded. As such, you'll likely want to apply a default nameserver
+as above if none can be found.
 
 > Note that the factory loads the hosts file from the filesystem once when
   creating the resolver instance.
@@ -61,8 +73,12 @@ You can cache results by configuring the resolver to use a `CachedExecutor`:
 
 ```php
 $loop = React\EventLoop\Factory::create();
+
+$config = React\Dns\Config\Config::loadSystemConfigBlocking();
+$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+
 $factory = new React\Dns\Resolver\Factory();
-$dns = $factory->createCached('8.8.8.8', $loop);
+$dns = $factory->createCached($server, $loop);
 
 $dns->resolve('igor.io')->then(function ($ip) {
     echo "Host: $ip\n";

--- a/examples/01-one.php
+++ b/examples/01-one.php
@@ -1,13 +1,17 @@
 <?php
 
+use React\Dns\Config\Config;
 use React\Dns\Resolver\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
+$config = Config::loadSystemConfigBlocking();
+$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+
 $factory = new Factory();
-$resolver = $factory->create('8.8.8.8', $loop);
+$resolver = $factory->create($server, $loop);
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 

--- a/examples/02-concurrent.php
+++ b/examples/02-concurrent.php
@@ -1,13 +1,17 @@
 <?php
 
+use React\Dns\Config\Config;
 use React\Dns\Resolver\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
+$config = Config::loadSystemConfigBlocking();
+$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+
 $factory = new Factory();
-$resolver = $factory->create('8.8.8.8', $loop);
+$resolver = $factory->create($server, $loop);
 
 $names = array_slice($argv, 1);
 if (!$names) {

--- a/examples/03-cached.php
+++ b/examples/03-cached.php
@@ -1,13 +1,17 @@
 <?php
 
+use React\Dns\Config\Config;
 use React\Dns\Resolver\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
+$config = Config::loadSystemConfigBlocking();
+$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+
 $factory = new Factory();
-$resolver = $factory->createCached('8.8.8.8', $loop);
+$resolver = $factory->createCached($server, $loop);
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -4,5 +4,28 @@ namespace React\Dns\Config;
 
 class Config
 {
+    /**
+     * Loads the system DNS configuration
+     *
+     * Note that this method may block while loading its internal files and/or
+     * commands and should thus be used with care! While this should be
+     * relatively fast for most systems, it remains unknown if this may block
+     * under certain circumstances. In particular, this method should only be
+     * executed before the loop starts, not while it is running.
+     *
+     * Note that this method will try to access its files and/or commands and
+     * try to parse its output. Currently, this is only a placeholder that does
+     * not actually parse any nameserver entries.
+     *
+     * Note that the previous section implies that this may return an empty
+     * `Config` object if no valid nameserver entries can be found.
+     *
+     * @return self
+     */
+    public static function loadSystemConfigBlocking()
+    {
+        return new self();
+    }
+
     public $nameservers = array();
 }


### PR DESCRIPTION
This simple PR adds the skeleton for loading the default system config. As per https://github.com/reactphp/dns/issues/29#issuecomment-363496689 it does not actually load any configuration, it merely adds the API that should be consumed to load the configuration. This PR mostly exists to discuss this API and to give an idea how this can be consumed.

It also adds documentation that a `Config` may be *empty*, which makes sense for a number of reasons. Once this PR is in, I will update https://github.com/reactphp/dns/pull/92 to use this API so that the `/etc/resolv.conf` will be loaded as expected. Once this is in, I will file a PR to add Windows support and consider this feature complete for now.

Refs #29
Refs #92