### PR TITLE
Support parsing multiple DNS entries for same interface from WMIC

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -115,7 +115,7 @@ class Config
     public static function loadWmicBlocking($command = null)
     {
         $contents = shell_exec($command === null ? 'wmic NICCONFIG get "DNSServerSearchOrder" /format:CSV' : $command);
-        preg_match_all('/(?:{|,|")([\da-f.:]{4,})(?:}|,|")/i', $contents, $matches);
+        preg_match_all('/(?<=[{;,"])([\da-f.:]{4,})(?=[};,"])/i', $contents, $matches);
 
         $config = new self();
         $config->nameservers = $matches[1];

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -152,7 +152,22 @@ ACE,
         $this->assertEquals($expected, $config->nameservers);
     }
 
-    public function testLoadsMultipleEntriesForSingleNicFromWmicOutput()
+    public function testLoadsMultipleEntriesForSingleNicWithSemicolonFromWmicOutput()
+    {
+        $contents = '
+Node,DNSServerSearchOrder
+ACE,
+ACE,{192.168.2.1;192.168.2.2}
+ACE,
+';
+        $expected = array('192.168.2.1', '192.168.2.2');
+
+        $config = Config::loadWmicBlocking($this->echoCommand($contents));
+
+        $this->assertEquals($expected, $config->nameservers);
+    }
+
+    public function testLoadsMultipleEntriesForSingleNicWithQuotesFromWmicOutput()
     {
         $contents = '
 Node,DNSServerSearchOrder


### PR DESCRIPTION
Windows allows setting multiple DNS servers for each network interface. After running the test suite on a number of test systems, it looks like at least Windows Server 2016 uses the WMIC output format `ACE,{192.168.2.1;192.168.2.2}`, while the test suite currently only tests for `ACE,{"192.168.2.1","192.168.2.2"}`.

Builds on top of #94