### PR TITLE
Remove unneeded cyclic dependency on react/socket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 sudo: false
 
 install:
-  - COMPOSER_ROOT_VERSION=`git describe --abbrev=0` composer install --no-interaction
+  - composer install --no-interaction
 
 script:
   - vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -163,12 +163,10 @@ It's *highly recommended to use PHP 7+* for this project.
 ## Tests
 
 To run the test suite, you first need to clone this repo and then install all
-dependencies [through Composer](https://getcomposer.org).
-Because the test suite contains some circular dependencies, you may have to
-manually specify the root package version like this:
+dependencies [through Composer](https://getcomposer.org):
 
 ```bash
-$ COMPOSER_ROOT_VERSION=`git describe --abbrev=0` composer install
+$ composer install
 ```
 
 To run the test suite, go to the project root and run:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
         "react/promise": "^2.1 || ^1.2.1",
         "react/promise-timer": "^1.2",
-        "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5 || ^0.4.4",
         "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.5"
     },
     "require-dev": {

--- a/tests/Query/ExecutorTest.php
+++ b/tests/Query/ExecutorTest.php
@@ -279,7 +279,7 @@ class ExecutorTest extends TestCase
 
     private function createConnectionMock($emitData = true)
     {
-        $conn = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $conn = $this->getMockBuilder('React\Stream\DuplexStreamInterface')->getMock();
         $conn
             ->expects($this->any())
             ->method('on')


### PR DESCRIPTION
This trivial PR removes the currently unneeded dependency on react/socket, which in turn depends on react/dns again. By removing this cyclic dependency, we can ensure Composer will automatically and correctly pick the latest installed version without having to specify the root package version.

This change was previously suggested by @cboden in #79. After considering this again, I came to the conclusion that I would rather get this in now and eventually look into how we can avoid this once we implement #19. This change includes documentation updates and effectively reverts parts of #71.

The updated dependency graph now looks like this:

![new dependency graph](https://user-images.githubusercontent.com/776829/36720037-17f95ec0-1ba7-11e8-9dc3-d50b14e4516c.png)

Builds on top of #79, thank you @cboden!