### PR TITLE
Rename DatagramTransportExecutor to UdpTransportExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ easily be used to create a DNS server.
 * [Caching](#caching)
   * [Custom cache adapter](#custom-cache-adapter)
 * [Advanced usage](#advanced-usage)
-  * [DatagramTransportExecutor](#datagramtransportexecutor)
+  * [UdpTransportExecutor](#udptransportexecutor)
   * [HostsFileExecutor](#hostsfileexecutor)
 * [Install](#install)
 * [Tests](#tests)
@@ -118,10 +118,10 @@ See also the wiki for possible [cache implementations](https://github.com/reactp
 
 ## Advanced Usage
 
-### DatagramTransportExecutor
+### UdpTransportExecutor
 
-The `DatagramTransportExecutor` can be used to
-send DNS queries over a datagram transport such as UDP.
+The `UdpTransportExecutor` can be used to
+send DNS queries over a UDP transport.
 
 This is the main class that sends a DNS query to your DNS server and is used
 internally by the `Resolver` for the actual message transport.
@@ -131,7 +131,7 @@ The following example looks up the `IPv6` address for `igor.io`.
 
 ```php
 $loop = Factory::create();
-$executor = new DatagramTransportExecutor($loop);
+$executor = new UdpTransportExecutor($loop);
 
 $executor->query(
     '8.8.8.8:53', 
@@ -152,7 +152,7 @@ want to use this in combination with a `TimeoutExecutor` like this:
 
 ```php
 $executor = new TimeoutExecutor(
-    new DatagramTransportExecutor($loop),
+    new UdpTransportExecutor($loop),
     3.0,
     $loop
 );
@@ -165,7 +165,7 @@ combination with a `RetryExecutor` like this:
 ```php
 $executor = new RetryExecutor(
     new TimeoutExecutor(
-        new DatagramTransportExecutor($loop),
+        new UdpTransportExecutor($loop),
         3.0,
         $loop
     )
@@ -180,14 +180,14 @@ $executor = new RetryExecutor(
 
 ### HostsFileExecutor
 
-Note that the above `Executor` class always performs an actual DNS query.
+Note that the above `UdpTransportExecutor` class always performs an actual DNS query.
 If you also want to take entries from your hosts file into account, you may
 use this code:
 
 ```php
 $hosts = \React\Dns\Config\HostsFile::loadFromPathBlocking();
 
-$executor = new Executor($loop, new Parser(), new BinaryDumper(), null);
+$executor = new UdpTransportExecutor($loop);
 $executor = new HostsFileExecutor($hosts, $executor);
 
 $executor->query(

--- a/examples/04-query-a-and-aaaa.php
+++ b/examples/04-query-a-and-aaaa.php
@@ -1,14 +1,14 @@
 <?php
 
 use React\Dns\Model\Message;
-use React\Dns\Query\DatagramTransportExecutor;
 use React\Dns\Query\Query;
+use React\Dns\Query\UdpTransportExecutor;
 use React\EventLoop\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$executor = new DatagramTransportExecutor($loop);
+$executor = new UdpTransportExecutor($loop);
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 

--- a/src/Query/Executor.php
+++ b/src/Query/Executor.php
@@ -13,7 +13,7 @@ use React\Stream\Stream;
 
 /**
  * @deprecated unused, exists for BC only
- * @see DatagramTransportExecutor
+ * @see UdpTransportExecutor
  */
 class Executor implements ExecutorInterface
 {

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -9,7 +9,7 @@ use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 
 /**
- * Send DNS queries over a datagram transport such as UDP.
+ * Send DNS queries over a UDP transport.
  *
  * This is the main class that sends a DNS query to your DNS server and is used
  * internally by the `Resolver` for the actual message transport.
@@ -19,11 +19,11 @@ use React\Promise\Deferred;
  *
  * ```php
  * $loop = Factory::create();
- * $executor = new DatagramTransportExecutor($loop);
+ * $executor = new UdpTransportExecutor($loop);
  *
  * $executor->query(
  *     '8.8.8.8:53',
- *     new Query($name, Message::TYPE_AAAA, Message::CLASS_IN, time())
+ *     new Query($name, Message::TYPE_AAAA, Message::CLASS_IN)
  * )->then(function (Message $message) {
  *     foreach ($message->answers as $answer) {
  *         echo 'IPv6: ' . $answer->data . PHP_EOL;
@@ -40,7 +40,7 @@ use React\Promise\Deferred;
  *
  * ```php
  * $executor = new TimeoutExecutor(
- *     new DatagramTransportExecutor($loop),
+ *     new UdpTransportExecutor($loop),
  *     3.0,
  *     $loop
  * );
@@ -53,7 +53,7 @@ use React\Promise\Deferred;
  * ```php
  * $executor = new RetryExecutor(
  *     new TimeoutExecutor(
- *         new DatagramTransportExecutor($loop),
+ *         new UdpTransportExecutor($loop),
  *         3.0,
  *         $loop
  *     )
@@ -66,7 +66,7 @@ use React\Promise\Deferred;
  *   packages. Higher-level components should take advantage of the Datagram
  *   component instead of reimplementing this socket logic from scratch.
  */
-class DatagramTransportExecutor implements ExecutorInterface
+class UdpTransportExecutor implements ExecutorInterface
 {
     private $loop;
     private $parser;

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -6,12 +6,12 @@ use React\Cache\ArrayCache;
 use React\Cache\CacheInterface;
 use React\Dns\Config\HostsFile;
 use React\Dns\Query\CachedExecutor;
-use React\Dns\Query\DatagramTransportExecutor;
 use React\Dns\Query\ExecutorInterface;
 use React\Dns\Query\HostsFileExecutor;
 use React\Dns\Query\RecordCache;
 use React\Dns\Query\RetryExecutor;
 use React\Dns\Query\TimeoutExecutor;
+use React\Dns\Query\UdpTransportExecutor;
 use React\EventLoop\LoopInterface;
 
 class Factory
@@ -69,7 +69,7 @@ class Factory
     protected function createExecutor(LoopInterface $loop)
     {
         return new TimeoutExecutor(
-            new DatagramTransportExecutor($loop),
+            new UdpTransportExecutor($loop),
             5.0,
             $loop
         );

--- a/tests/Query/UdpTransportExecutorTest.php
+++ b/tests/Query/UdpTransportExecutorTest.php
@@ -2,15 +2,15 @@
 
 namespace React\Tests\Dns\Query;
 
-use React\Tests\Dns\TestCase;
-use React\Dns\Query\DatagramTransportExecutor;
-use React\Dns\Query\Query;
 use React\Dns\Model\Message;
-use React\EventLoop\Factory;
-use React\Dns\Protocol\Parser;
 use React\Dns\Protocol\BinaryDumper;
+use React\Dns\Protocol\Parser;
+use React\Dns\Query\Query;
+use React\Dns\Query\UdpTransportExecutor;
+use React\EventLoop\Factory;
+use React\Tests\Dns\TestCase;
 
-class DatagramTransportExecutorTest extends TestCase
+class UdpTransportExecutorTest extends TestCase
 {
     public function testQueryRejectsIfMessageExceedsUdpSize()
     {
@@ -20,7 +20,7 @@ class DatagramTransportExecutorTest extends TestCase
         $dumper = $this->getMockBuilder('React\Dns\Protocol\BinaryDumper')->getMock();
         $dumper->expects($this->once())->method('toBinary')->willReturn(str_repeat('.', 513));
 
-        $executor = new DatagramTransportExecutor($loop, null, $dumper);
+        $executor = new UdpTransportExecutor($loop, null, $dumper);
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
         $promise = $executor->query('8.8.8.8:53', $query);
@@ -34,7 +34,7 @@ class DatagramTransportExecutorTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->never())->method('addReadStream');
 
-        $executor = new DatagramTransportExecutor($loop);
+        $executor = new UdpTransportExecutor($loop);
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
         $promise = $executor->query('///', $query);
@@ -52,7 +52,7 @@ class DatagramTransportExecutorTest extends TestCase
         $loop->expects($this->once())->method('addReadStream');
         $loop->expects($this->once())->method('removeReadStream');
 
-        $executor = new DatagramTransportExecutor($loop);
+        $executor = new UdpTransportExecutor($loop);
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
         $promise = $executor->query('8.8.8.8:53', $query);
@@ -66,7 +66,7 @@ class DatagramTransportExecutorTest extends TestCase
     {
         $loop = Factory::create();
 
-        $executor = new DatagramTransportExecutor($loop);
+        $executor = new UdpTransportExecutor($loop);
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
 
@@ -94,7 +94,7 @@ class DatagramTransportExecutorTest extends TestCase
         });
 
         $address = stream_socket_get_name($server, false);
-        $executor = new DatagramTransportExecutor($loop);
+        $executor = new UdpTransportExecutor($loop);
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
 
@@ -129,7 +129,7 @@ class DatagramTransportExecutorTest extends TestCase
         });
 
         $address = stream_socket_get_name($server, false);
-        $executor = new DatagramTransportExecutor($loop, $parser, $dumper);
+        $executor = new UdpTransportExecutor($loop, $parser, $dumper);
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
 
@@ -164,7 +164,7 @@ class DatagramTransportExecutorTest extends TestCase
         });
 
         $address = stream_socket_get_name($server, false);
-        $executor = new DatagramTransportExecutor($loop, $parser, $dumper);
+        $executor = new UdpTransportExecutor($loop, $parser, $dumper);
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
 
@@ -203,7 +203,7 @@ class DatagramTransportExecutorTest extends TestCase
         });
 
         $address = stream_socket_get_name($server, false);
-        $executor = new DatagramTransportExecutor($loop, $parser, $dumper);
+        $executor = new UdpTransportExecutor($loop, $parser, $dumper);
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
 


### PR DESCRIPTION
This simple PR renames the `DatagramTransportExecutor` (recently introduced via #101) to `UdpTransportExecutor`. This is done to be in line with the DNS RFC terminology (https://tools.ietf.org/html/rfc1035#section-4.2), because it is less misleading (this class can only really support UDP) and also because for future TCP/IP transport the name "streaming" makes even less sense and they should be named `TcpTransportExecutor` (#19) and `TlsTransportExecutor` (#80) respectively. I'm not marking this as BC break because this will be renamed as part of the same release, so outside consumers of this package should not be affected.