### PR TITLE
Support parsing SOA records

### DIFF
--- a/examples/11-query-any.php
+++ b/examples/11-query-any.php
@@ -48,6 +48,11 @@ $executor->query('8.8.8.8:53', $any)->then(function (Message $message) {
                 $type = 'MX';
                 $data = implode(' ', $data);
                 break;
+            case Message::TYPE_SOA:
+                // SOA records contain structured data, dump structure here
+                $type = 'SOA';
+                $data = json_encode($data);
+                break;
             default:
                 // unknown type uses HEX format
                 $type = 'Type ' . $answer->type;

--- a/src/Model/Record.php
+++ b/src/Model/Record.php
@@ -56,6 +56,12 @@ class Record
      *   referred to as exchange). If a response message contains multiple
      *   records of this type, targets should be sorted by priority (lowest
      *   first) - this is left up to consumers of this library (used for SMTP).
+     * - SOA:
+     *   Includes master hostname without trailing dot, responsible person email
+     *   as hostname without trailing dot and serial, refresh, retry, expire and
+     *   minimum times in seconds (UINT32 each), for example:
+     *   `{"mname":"ns.example.com","rname":"hostmaster.example.com","serial":
+     *   2018082601,"refresh":3600,"retry":1800,"expire":60000,"minimum":3600}`.
      * - Any other unknown type:
      *   An opaque binary string containing the RDATA as transported in the DNS
      *   record. For forwards compatibility, you should not rely on this format

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -185,6 +185,21 @@ class Parser
                 'priority' => $priority,
                 'target' => implode('.', $bodyLabels)
             );
+        } elseif (Message::TYPE_SOA === $type) {
+            list($primaryLabels, $consumed) = $this->readLabels($message->data, $consumed);
+            list($mailLabels, $consumed) = $this->readLabels($message->data, $consumed);
+            list($serial, $refresh, $retry, $expire, $minimum) = array_values(unpack('N*', substr($message->data, $consumed, 20)));
+            $consumed += 20;
+
+            $rdata = array(
+                'mname' => implode('.', $primaryLabels),
+                'rname' => implode('.', $mailLabels),
+                'serial' => $serial,
+                'refresh' => $refresh,
+                'retry' => $retry,
+                'expire' => $expire,
+                'minimum' => $minimum
+            );
         } else {
             // unknown types simply parse rdata as an opaque binary string
             $rdata = substr($message->data, $consumed, $rdLength);


### PR DESCRIPTION
This PR adds support for parsing `SOA` records. These are commonly included when performing `ANY` queries (#104) and are also useful for negative caching in the future (#81).

Builds on top of #104, #105 and #106
Refs #31