### PR TITLE
Improve error messages for failed queries and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ easily be used to create a DNS server.
 * [Basic usage](#basic-usage)
 * [Caching](#caching)
   * [Custom cache adapter](#custom-cache-adapter)
+* [Resolver](#resolver)
+  * [resolve()](#resolve)
 * [Advanced usage](#advanced-usage)
   * [UdpTransportExecutor](#udptransportexecutor)
   * [HostsFileExecutor](#hostsfileexecutor)
@@ -57,14 +59,6 @@ as above if none can be found.
   creating the resolver instance.
   Ideally, this method should thus be executed only once before the loop starts
   and not repeatedly while it is running.
-
-Pending DNS queries can be cancelled by cancelling its pending promise like so:
-
-```php
-$promise = $resolver->resolve('reactphp.org');
-
-$promise->cancel();
-```
 
 But there's more.
 
@@ -115,6 +109,42 @@ $dns = $factory->createCached('8.8.8.8', $loop, $cache);
 ```
 
 See also the wiki for possible [cache implementations](https://github.com/reactphp/react/wiki/Users#cache-implementations).
+
+## Resolver
+
+### resolve()
+
+The `resolve(string $domain): PromiseInterface<string,Exception>` method can be used to
+resolve the given $domain name to a single IPv4 address (type `A` query).
+
+```php
+$resolver->resolve('reactphp.org')->then(function ($ip) {
+    echo 'IP for reactphp.org is ' . $ip . PHP_EOL;
+});
+```
+
+This is one of the main methods in this package. It sends a DNS query
+for the given $domain name to your DNS server and returns a single IP
+address on success.
+
+If the DNS server sends a DNS response message that contains more than
+one IP address for this query, it will randomly pick one of the IP
+addresses from the response.
+
+If the DNS server sends a DNS response message that indicated an error
+code, this method will reject with a `RecordNotFoundException`. Its
+message and code can be used to check for the response code.
+
+If the DNS communication fails and the server does not respond with a
+valid response message, this message will reject with an `Exception`.
+
+Pending DNS queries can be cancelled by cancelling its pending promise like so:
+
+```php
+$promise = $resolver->resolve('reactphp.org');
+
+$promise->cancel();
+```
 
 ## Advanced Usage
 

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -137,6 +137,16 @@ class Message
         return $this->header->get('id');
     }
 
+    /**
+     * Returns the response code (RCODE)
+     *
+     * @return int see self::RCODE_* constants
+     */
+    public function getResponseCode()
+    {
+        return $this->header->get('rcode');
+    }
+
     public function prepare()
     {
         $this->header->populateCounts($this);

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -6,6 +6,7 @@ use React\Dns\Query\ExecutorInterface;
 use React\Dns\Query\Query;
 use React\Dns\RecordNotFoundException;
 use React\Dns\Model\Message;
+use React\Promise\PromiseInterface;
 
 class Resolver
 {
@@ -18,6 +19,42 @@ class Resolver
         $this->executor = $executor;
     }
 
+    /**
+     * Resolves the given $domain name to a single IPv4 address (type `A` query).
+     *
+     * ```php
+     * $resolver->resolve('reactphp.org')->then(function ($ip) {
+     *     echo 'IP for reactphp.org is ' . $ip . PHP_EOL;
+     * });
+     * ```
+     *
+     * This is one of the main methods in this package. It sends a DNS query
+     * for the given $domain name to your DNS server and returns a single IP
+     * address on success.
+     *
+     * If the DNS server sends a DNS response message that contains more than
+     * one IP address for this query, it will randomly pick one of the IP
+     * addresses from the response.
+     *
+     * If the DNS server sends a DNS response message that indicated an error
+     * code, this method will reject with a `RecordNotFoundException`. Its
+     * message and code can be used to check for the response code.
+     *
+     * If the DNS communication fails and the server does not respond with a
+     * valid response message, this message will reject with an `Exception`.
+     *
+     * Pending DNS queries can be cancelled by cancelling its pending promise like so:
+     *
+     * ```php
+     * $promise = $resolver->resolve('reactphp.org');
+     *
+     * $promise->cancel();
+     * ```
+     *
+     * @param string $domain
+     * @return PromiseInterface Returns a promise which resolves with a single IP address on success or
+     *     rejects with an Exception on error.
+     */
     public function resolve($domain)
     {
         $query = new Query($domain, Message::TYPE_A, Message::CLASS_IN);
@@ -32,13 +69,42 @@ class Resolver
 
     public function extractAddress(Query $query, Message $response)
     {
-        $answers = $response->answers;
+        // reject if response code indicates this is an error response message
+        $code = $response->getResponseCode();
+        if ($code !== Message::RCODE_OK) {
+            switch ($code) {
+                case Message::RCODE_FORMAT_ERROR:
+                    $message = 'Format Error';
+                    break;
+                case Message::RCODE_SERVER_FAILURE:
+                    $message = 'Server Failure';
+                    break;
+                case Message::RCODE_NAME_ERROR:
+                    $message = 'Non-Existent Domain / NXDOMAIN';
+                    break;
+                case Message::RCODE_NOT_IMPLEMENTED:
+                    $message = 'Not Implemented';
+                    break;
+                case Message::RCODE_REFUSED:
+                    $message = 'Refused';
+                    break;
+                default:
+                    $message = 'Unknown error response code ' . $code;
+            }
+            throw new RecordNotFoundException(
+                'DNS query for ' . $query->name . ' returned an error response (' . $message . ')',
+                $code
+            );
+        }
 
+        $answers = $response->answers;
         $addresses = $this->resolveAliases($answers, $query->name);
 
+        // reject if we did not receive a valid answer (domain is valid, but no record for this type could be found)
         if (0 === count($addresses)) {
-            $message = 'DNS Request did not return valid answer.';
-            throw new RecordNotFoundException($message);
+            throw new RecordNotFoundException(
+                'DNS query for ' . $query->name . ' did not return a valid answer (NOERROR / NODATA)'
+            );
         }
 
         $address = $addresses[array_rand($addresses)];

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -2,10 +2,10 @@
 
 namespace React\Tests\Dns;
 
-use React\Tests\Dns\TestCase;
 use React\EventLoop\Factory as LoopFactory;
-use React\Dns\Resolver\Resolver;
 use React\Dns\Resolver\Factory;
+use React\Dns\RecordNotFoundException;
+use React\Dns\Model\Message;
 
 class FunctionalTest extends TestCase
 {
@@ -41,16 +41,24 @@ class FunctionalTest extends TestCase
      */
     public function testResolveInvalidRejects()
     {
+        $ex = $this->callback(function ($param) {
+            return ($param instanceof RecordNotFoundException && $param->getCode() === Message::RCODE_NAME_ERROR);
+        });
+
         $promise = $this->resolver->resolve('example.invalid');
-        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnceWith($ex));
 
         $this->loop->run();
     }
 
     public function testResolveCancelledRejectsImmediately()
     {
+        $ex = $this->callback(function ($param) {
+            return ($param instanceof \RuntimeException && $param->getMessage() === 'DNS query for google.com has been cancelled');
+        });
+
         $promise = $this->resolver->resolve('google.com');
-        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnceWith($ex));
         $promise->cancel();
 
         $time = microtime(true);

--- a/tests/Model/MessageTest.php
+++ b/tests/Model/MessageTest.php
@@ -26,5 +26,6 @@ class MessageTest extends TestCase
         $this->assertFalse($request->header->isQuery());
         $this->assertTrue($request->header->isResponse());
         $this->assertEquals(0, $request->header->get('anCount'));
+        $this->assertEquals(Message::RCODE_OK, $request->getResponseCode());
     }
 }


### PR DESCRIPTION
This PR improves error messages when a response message indicates an error. This adds relevant documentation for the `resolve()` method in preparation for the future `resolveAll()` method as discussed in #43.