### PR TITLE
Add reverse DNS lookup example

### DIFF
--- a/examples/13-reverse-dns.php
+++ b/examples/13-reverse-dns.php
@@ -1,0 +1,35 @@
+<?php
+
+use React\Dns\Config\Config;
+use React\Dns\Resolver\Factory;
+use React\Dns\Model\Message;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = React\EventLoop\Factory::create();
+
+$config = Config::loadSystemConfigBlocking();
+$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+
+$factory = new Factory();
+$resolver = $factory->create($server, $loop);
+
+$ip = isset($argv[1]) ? $argv[1] : '8.8.8.8';
+
+if (@inet_pton($ip) === false) {
+    exit('Error: Given argument is not a valid IP' . PHP_EOL);
+}
+
+if (strpos($ip, ':') === false) {
+    $name = inet_ntop(strrev(inet_pton($ip))) . '.in-addr.arpa';
+} else {
+    $name = wordwrap(strrev(bin2hex(inet_pton($ip))), 1, '.', true) . '.ip6.arpa';
+}
+
+$resolver->resolveAll($name, Message::TYPE_PTR)->then(function (array $names) {
+    var_dump($names);
+}, function (Exception $e) {
+    echo $e->getMessage() . PHP_EOL;
+});
+
+$loop->run();


### PR DESCRIPTION
This simple PR adds an example to show how this library can be used to send reverse DNS lookups (look up the hostnames that an IP points to). This is commonly used in email setups to prevent spam.

This PR only adds an example, it does not change our public API. It's currently unclear if this lookup warrants a dedicated method in the `Resolver` class, I'll leave this out for now with the idea to evaluate this again if we see a need for this.

Resolves / closes #25 
Builds on top of #110 