### PR TITLE
Fix caching advanced MX/SRV/TXT/SOA structures

### DIFF
--- a/src/Query/RecordBag.php
+++ b/src/Query/RecordBag.php
@@ -2,7 +2,6 @@
 
 namespace React\Dns\Query;
 
-use React\Dns\Model\Message;
 use React\Dns\Model\Record;
 
 class RecordBag
@@ -11,7 +10,7 @@ class RecordBag
 
     public function set($currentTime, Record $record)
     {
-        $this->records[$record->data] = array($currentTime + $record->ttl, $record);
+        $this->records[] = array($currentTime + $record->ttl, $record);
     }
 
     public function all()

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -47,6 +47,20 @@ class FunctionalTest extends TestCase
     /**
      * @group internet
      */
+    public function testResolveAllGoogleMxResolvesWithCache()
+    {
+        $factory = new Factory();
+        $this->resolver = $factory->createCached('8.8.8.8', $this->loop);
+
+        $promise = $this->resolver->resolveAll('google.com', Message::TYPE_MX);
+        $promise->then($this->expectCallableOnceWith($this->isType('array')), $this->expectCallableNever());
+
+        $this->loop->run();
+    }
+
+    /**
+     * @group internet
+     */
     public function testResolveInvalidRejects()
     {
         $ex = $this->callback(function ($param) {

--- a/tests/Query/RecordBagTest.php
+++ b/tests/Query/RecordBagTest.php
@@ -39,6 +39,25 @@ class RecordBagTest extends TestCase
     }
 
     /**
+     * @covers React\Dns\Query\RecordBag
+     * @test
+     */
+    public function setShouldAcceptMxRecord()
+    {
+        $currentTime = 1345656451;
+
+        $recordBag = new RecordBag();
+        $recordBag->set($currentTime, new Record('igor.io', Message::TYPE_MX, Message::CLASS_IN, 3600, array('priority' => 10, 'target' => 'igor.io')));
+
+        $records = $recordBag->all();
+        $this->assertCount(1, $records);
+        $this->assertSame('igor.io', $records[0]->name);
+        $this->assertSame(Message::TYPE_MX, $records[0]->type);
+        $this->assertSame(Message::CLASS_IN, $records[0]->class);
+        $this->assertSame(array('priority' => 10, 'target' => 'igor.io'), $records[0]->data);
+    }
+
+    /**
     * @covers React\Dns\Query\RecordBag
     * @test
     */


### PR DESCRIPTION
This PR fixes a minor array offset issue when using the `Factory::createCached()` method (not recommended by default?). The `Record::$data` property may hold structured data for MX/SRV/TXT/SOA records as of #105 and others, as such it must not be used as an array index.