### PR TITLE
Fix interpretation of TTL as UINT32 with most significant bit unset

### DIFF
--- a/src/Model/Record.php
+++ b/src/Model/Record.php
@@ -20,7 +20,8 @@ class Record
     public $class;
 
     /**
-     * @var int maximum TTL in seconds (UINT16)
+     * @var int maximum TTL in seconds (UINT32, most significant bit always unset)
+     * @link https://tools.ietf.org/html/rfc2181#section-8
      */
     public $ttl;
 

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -154,6 +154,11 @@ class Parser
         list($ttl) = array_values(unpack('N', substr($message->data, $consumed, 4)));
         $consumed += 4;
 
+        // TTL is a UINT32 that must not have most significant bit set for BC reasons
+        if ($ttl < 0 || $ttl >= 1 << 31) {
+            $ttl = 0;
+        }
+
         list($rdLength) = array_values(unpack('n', substr($message->data, $consumed, 2)));
         $consumed += 2;
 
@@ -219,7 +224,6 @@ class Parser
         $message->consumed = $consumed;
 
         $name = implode('.', $labels);
-        $ttl = $this->signedLongToUnsignedLong($ttl);
         $record = new Record($name, $type, $class, $ttl, $rdata);
 
         $message->answers[] = $record;
@@ -291,6 +295,10 @@ class Parser
         return array($peek & $mask, $consumed + 2);
     }
 
+    /**
+     * @deprecated unused, exists for BC only
+     * @codeCoverageIgnore
+     */
     public function signedLongToUnsignedLong($i)
     {
         return $i & 0x80000000 ? $i - 0xffffffff : $i;


### PR DESCRIPTION
TTL is actually a UINT32 with most significant bit unset for BC reasons as per https://tools.ietf.org/html/rfc2181#section-8. This will not affect "normal" operation as the most significant bit should not be set by compliant implementations and we will now interpret this accordingly.

Refs #81
Refs #114