### PR TITLE
Reject parsing malformed record data and incomplete DNS response messages

### DIFF
--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -127,9 +127,9 @@ class Parser
     {
         $consumed = $message->consumed;
 
-        list($labels, $consumed) = $this->readLabels($message->data, $consumed);
+        list($name, $consumed) = $this->readDomain($message->data, $consumed);
 
-        if ($labels === null || !isset($message->data[$consumed + 10 - 1])) {
+        if ($name === null || !isset($message->data[$consumed + 10 - 1])) {
             return;
         }
 
@@ -152,67 +152,80 @@ class Parser
         }
 
         $rdata = null;
+        $expected = $consumed + $rdLength;
 
-        if (Message::TYPE_A === $type || Message::TYPE_AAAA === $type) {
-            $ip = substr($message->data, $consumed, $rdLength);
-            $consumed += $rdLength;
-
-            $rdata = inet_ntop($ip);
+        if (Message::TYPE_A === $type) {
+            if ($rdLength === 4) {
+                $rdata = inet_ntop(substr($message->data, $consumed, $rdLength));
+                $consumed += $rdLength;
+            }
+        } elseif (Message::TYPE_AAAA === $type) {
+            if ($rdLength === 16) {
+                $rdata = inet_ntop(substr($message->data, $consumed, $rdLength));
+                $consumed += $rdLength;
+            }
         } elseif (Message::TYPE_CNAME === $type || Message::TYPE_PTR === $type || Message::TYPE_NS === $type) {
-            list($bodyLabels, $consumed) = $this->readLabels($message->data, $consumed);
-
-            $rdata = implode('.', $bodyLabels);
+            list($rdata, $consumed) = $this->readDomain($message->data, $consumed);
         } elseif (Message::TYPE_TXT === $type) {
             $rdata = array();
-            $remaining = $rdLength;
-            while ($remaining) {
+            while ($consumed < $expected) {
                 $len = ord($message->data[$consumed]);
-                $rdata[] = substr($message->data, $consumed + 1, $len);
+                $rdata[] = (string)substr($message->data, $consumed + 1, $len);
                 $consumed += $len + 1;
-                $remaining -= $len + 1;
             }
         } elseif (Message::TYPE_MX === $type) {
-            list($priority) = array_values(unpack('n', substr($message->data, $consumed, 2)));
-            list($bodyLabels, $consumed) = $this->readLabels($message->data, $consumed + 2);
+            if ($rdLength > 2) {
+                list($priority) = array_values(unpack('n', substr($message->data, $consumed, 2)));
+                list($target, $consumed) = $this->readDomain($message->data, $consumed + 2);
 
-            $rdata = array(
-                'priority' => $priority,
-                'target' => implode('.', $bodyLabels)
-            );
+                $rdata = array(
+                    'priority' => $priority,
+                    'target' => $target
+                );
+            }
         } elseif (Message::TYPE_SRV === $type) {
-            list($priority, $weight, $port) = array_values(unpack('n*', substr($message->data, $consumed, 6)));
-            list($bodyLabels, $consumed) = $this->readLabels($message->data, $consumed + 6);
+            if ($rdLength > 6) {
+                list($priority, $weight, $port) = array_values(unpack('n*', substr($message->data, $consumed, 6)));
+                list($target, $consumed) = $this->readDomain($message->data, $consumed + 6);
 
-            $rdata = array(
-                'priority' => $priority,
-                'weight' => $weight,
-                'port' => $port,
-                'target' => implode('.', $bodyLabels)
-            );
+                $rdata = array(
+                    'priority' => $priority,
+                    'weight' => $weight,
+                    'port' => $port,
+                    'target' => $target
+                );
+            }
         } elseif (Message::TYPE_SOA === $type) {
-            list($primaryLabels, $consumed) = $this->readLabels($message->data, $consumed);
-            list($mailLabels, $consumed) = $this->readLabels($message->data, $consumed);
-            list($serial, $refresh, $retry, $expire, $minimum) = array_values(unpack('N*', substr($message->data, $consumed, 20)));
-            $consumed += 20;
+            list($mname, $consumed) = $this->readDomain($message->data, $consumed);
+            list($rname, $consumed) = $this->readDomain($message->data, $consumed);
 
-            $rdata = array(
-                'mname' => implode('.', $primaryLabels),
-                'rname' => implode('.', $mailLabels),
-                'serial' => $serial,
-                'refresh' => $refresh,
-                'retry' => $retry,
-                'expire' => $expire,
-                'minimum' => $minimum
-            );
+            if ($mname !== null && $rname !== null && isset($message->data[$consumed + 20 - 1])) {
+                list($serial, $refresh, $retry, $expire, $minimum) = array_values(unpack('N*', substr($message->data, $consumed, 20)));
+                $consumed += 20;
+
+                $rdata = array(
+                    'mname' => $mname,
+                    'rname' => $rname,
+                    'serial' => $serial,
+                    'refresh' => $refresh,
+                    'retry' => $retry,
+                    'expire' => $expire,
+                    'minimum' => $minimum
+                );
+            }
         } else {
             // unknown types simply parse rdata as an opaque binary string
             $rdata = substr($message->data, $consumed, $rdLength);
             $consumed += $rdLength;
         }
 
+        // ensure parsing record data consumes expact number of bytes indicated in record length
+        if ($consumed !== $expected || $rdata === null) {
+            return;
+        }
+
         $message->consumed = $consumed;
 
-        $name = implode('.', $labels);
         $record = new Record($name, $type, $class, $ttl, $rdata);
 
         $message->answers[] = $record;
@@ -222,6 +235,17 @@ class Parser
         }
 
         return $message;
+    }
+
+    private function readDomain($data, $consumed)
+    {
+        list ($labels, $consumed) = $this->readLabels($data, $consumed);
+
+        if ($labels === null) {
+            return array(null, null);
+        }
+
+        return array(implode('.', $labels), $consumed);
     }
 
     private function readLabels($data, $consumed)

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -66,7 +66,7 @@ class Parser
 
     public function parseHeader(Message $message)
     {
-        if (strlen($message->data) < 12) {
+        if (!isset($message->data[12 - 1])) {
             return;
         }
 
@@ -97,19 +97,11 @@ class Parser
 
     public function parseQuestion(Message $message)
     {
-        if (strlen($message->data) < 2) {
-            return;
-        }
-
         $consumed = $message->consumed;
 
         list($labels, $consumed) = $this->readLabels($message->data, $consumed);
 
-        if (null === $labels) {
-            return;
-        }
-
-        if (strlen($message->data) - $consumed < 4) {
+        if ($labels === null || !isset($message->data[$consumed + 4 - 1])) {
             return;
         }
 
@@ -133,19 +125,11 @@ class Parser
 
     public function parseAnswer(Message $message)
     {
-        if (strlen($message->data) < 2) {
-            return;
-        }
-
         $consumed = $message->consumed;
 
         list($labels, $consumed) = $this->readLabels($message->data, $consumed);
 
-        if (null === $labels) {
-            return;
-        }
-
-        if (strlen($message->data) - $consumed < 10) {
+        if ($labels === null || !isset($message->data[$consumed + 10 - 1])) {
             return;
         }
 
@@ -162,6 +146,10 @@ class Parser
 
         list($rdLength) = array_values(unpack('n', substr($message->data, $consumed, 2)));
         $consumed += 2;
+
+        if (!isset($message->data[$consumed + $rdLength - 1])) {
+            return;
+        }
 
         $rdata = null;
 
@@ -262,6 +250,7 @@ class Parser
 
                 $consumed += 2;
                 list($newLabels) = $this->readLabels($data, $offset);
+
                 if ($newLabels === null) {
                     return array(null, null);
                 }

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -690,6 +690,41 @@ class ParserTest extends TestCase
         $this->parser->parseMessage($data);
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testParseIncompleteAnswerFieldsThrows()
+    {
+        $data = "";
+        $data .= "72 62 81 80 00 01 00 01 00 00 00 00"; // header
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // question: igor.io
+        $data .= "00 01 00 01";                         // question: type A, class IN
+        $data .= "c0 0c";                               // answer: offset pointer to igor.io
+
+        $data = $this->convertTcpDumpToBinary($data);
+
+        $this->parser->parseMessage($data);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testParseIncompleteAnswerRecordDataThrows()
+    {
+        $data = "";
+        $data .= "72 62 81 80 00 01 00 01 00 00 00 00"; // header
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // question: igor.io
+        $data .= "00 01 00 01";                         // question: type A, class IN
+        $data .= "c0 0c";                               // answer: offset pointer to igor.io
+        $data .= "00 01 00 01";                         // answer: type A, class IN
+        $data .= "00 01 51 80";                         // answer: ttl 86400
+        $data .= "00 04";                               // answer: rdlength 4
+
+        $data = $this->convertTcpDumpToBinary($data);
+
+        $this->parser->parseMessage($data);
+    }
+
     private function convertTcpDumpToBinary($input)
     {
         // sudo ngrep -d en1 -x port 53


### PR DESCRIPTION
This PR ensures that each record data is valid according to its type, e.g. an `A` record MUST always have a 4 byte IPv4 address. This should not affect normal operation of compliant DNS servers, but we now ensure that invalid response messages no longer cause any parsing errors on our side. I've added test cases to cover each possible parsing error so that this has 100% test coverage.

Builds on top of #115