### PR TITLE
Forward compatibility with upcoming Cache v0.6 and Cache v1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.0",
-        "react/cache": "^0.5 || ^0.4 || ^0.3",
+        "react/cache": "^1.0 || ^0.6 || ^0.5 || ^0.4 || ^0.3",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
         "react/promise": "^2.1 || ^1.2.1",
         "react/promise-timer": "^1.2",


### PR DESCRIPTION
Cache v0.6 is going to be tagged soon: https://github.com/reactphp/cache/milestone/4. This component is already compatible with both the upcoming version as well as legacy versions. The Cache component is pretty much stable already and we plan to not introduce any BC breaks anymore: https://github.com/reactphp/cache/issues/8

Builds on top of #102