### PR TITLE
Improve test suite to add forward compatibility with PHPUnit 7, test against PHP 7.3 and use legacy PHPUnit 5 on legacy HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm # ignore errors, see below
+  - 7.3
+# - hhvm # requires legacy phpunit & ignore errors, see below
 
 # lock distro so new future defaults will not break the build
 dist: trusty
@@ -17,6 +18,8 @@ matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: hhvm
+      install: composer require phpunit/phpunit:^5 --dev --no-interaction
   allow_failures:
     - php: hhvm
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": { "React\\Dns\\": "src" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>


### PR DESCRIPTION
Builds on top of #85  and https://github.com/clue/php-socket-raw/pull/42