### PR TITLE
Support parsing `authority` and `additional` records from DNS response

### DIFF
--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -100,10 +100,44 @@ class Message
         return mt_rand(0, 0xffff);
     }
 
+    /**
+     * @var HeaderBag
+     */
     public $header;
+
+    /**
+     * This should be an array of Query objects. For BC reasons, this currently
+     * references a nested array with a structure that results from casting the
+     * Query objects to an array:
+     *
+     * ```php
+     * $questions = array(
+     *     array(
+     *         'name' => 'reactphp.org',
+     *         'type' => Message::TYPE_A,
+     *         'class' => Message::CLASS_IN
+     *     )
+     * );
+     * ```
+     *
+     * @var array
+     * @see Query
+     */
     public $questions = array();
+
+    /**
+     * @var Record[]
+     */
     public $answers = array();
+
+    /**
+     * @var Record[]
+     */
     public $authority = array();
+
+    /**
+     * @var Record[]
+     */
     public $additional = array();
 
     /**

--- a/src/Model/Record.php
+++ b/src/Model/Record.php
@@ -87,6 +87,13 @@ class Record
      */
     public $data;
 
+    /**
+     * @param string                $name
+     * @param int                   $type
+     * @param int                   $class
+     * @param int                   $ttl
+     * @param string|string[]|array $data
+     */
     public function __construct($name, $type, $class, $ttl = 0, $data = null)
     {
         $this->name     = $name;


### PR DESCRIPTION
This PR adds support for parsing `authority` and `additional` records from DNS response messages in accordance to [RFC 1035](https://tools.ietf.org/html/rfc1035#section-4.1). Among others, this is a prerequisite for parsing EDNS0 responses (#100) which is left up to a follow-up PR. This is a pure feature addition (without any BC breaks), though this is not currently used in practice.

Resolves #32