### PR TITLE
Cooperatively resolve hosts to avoid running same query concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,26 @@ $executor = new RetryExecutor(
 );
 ```
 
+Note that this executor is entirely async and as such allows you to execute
+any number of queries concurrently. You should probably limit the number of
+concurrent queries in your application or you're very likely going to face
+rate limitations and bans on the resolver end. For many common applications,
+you may want to avoid sending the same query multiple times when the first
+one is still pending, so you will likely want to use this in combination with
+a `CoopExecutor` like this:
+
+```php
+$executor = new CoopExecutor(
+    new RetryExecutor(
+        new TimeoutExecutor(
+            new UdpTransportExecutor($loop),
+            3.0,
+            $loop
+        )
+    )
+);
+```
+
 > Internally, this class uses PHP's UDP sockets and does not take advantage
   of [react/datagram](https://github.com/reactphp/datagram) purely for
   organizational reasons to avoid a cyclic dependency between the two

--- a/src/Query/CoopExecutor.php
+++ b/src/Query/CoopExecutor.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace React\Dns\Query;
+
+use React\Promise\Promise;
+
+/**
+ * Cooperatively resolves hosts via the given base executor to ensure same query is not run concurrently
+ *
+ * Wraps an existing `ExecutorInterface` to keep tracking of pending queries
+ * and only starts a new query when the same query is not already pending. Once
+ * the underlying query is fulfilled/rejected, it will forward its value to all
+ * promises awaiting the same query.
+ *
+ * This means it will not limit concurrency for queries that differ, for example
+ * when sending many queries for different host names or types.
+ *
+ * This is useful because all executors are entirely async and as such allow you
+ * to execute any number of queries concurrently. You should probably limit the
+ * number of concurrent queries in your application or you're very likely going
+ * to face rate limitations and bans on the resolver end. For many common
+ * applications, you may want to avoid sending the same query multiple times
+ * when the first one is still pending, so you will likely want to use this in
+ * combination with some other executor like this:
+ *
+ * ```php
+ * $executor = new CoopExecutor(
+ *     new RetryExecutor(
+ *         new TimeoutExecutor(
+ *             new UdpTransportExecutor($loop),
+ *             3.0,
+ *             $loop
+ *         )
+ *     )
+ * );
+ * ```
+ */
+class CoopExecutor implements ExecutorInterface
+{
+    private $executor;
+    private $pending = array();
+    private $counts = array();
+
+    public function __construct(ExecutorInterface $base)
+    {
+        $this->executor = $base;
+    }
+
+    public function query($nameserver, Query $query)
+    {
+        $key = $this->serializeQueryToIdentity($query);
+        if (isset($this->pending[$key])) {
+            // same query is already pending, so use shared reference to pending query
+            $promise = $this->pending[$key];
+            ++$this->counts[$key];
+        } else {
+            // no such query pending, so start new query and keep reference until it's fulfilled or rejected
+            $promise = $this->executor->query($nameserver, $query);
+            $this->pending[$key] = $promise;
+            $this->counts[$key] = 1;
+
+            $pending =& $this->pending;
+            $counts =& $this->counts;
+            $promise->then(function () use ($key, &$pending, &$counts) {
+                unset($pending[$key], $counts[$key]);
+            }, function () use ($key, &$pending, &$counts) {
+                unset($pending[$key], $counts[$key]);
+            });
+        }
+
+        // Return a child promise awaiting the pending query.
+        // Cancelling this child promise should only cancel the pending query
+        // when no other child promise is awaiting the same query.
+        $pending =& $this->pending;
+        $counts =& $this->counts;
+        return new Promise(function ($resolve, $reject) use ($promise) {
+            $promise->then($resolve, $reject);
+        }, function () use ($promise, $key, $query, &$pending, &$counts) {
+            if (--$counts[$key] < 1) {
+                unset($pending[$key], $counts[$key]);
+                $promise->cancel();
+            }
+            throw new \RuntimeException('DNS query for ' . $query->name . ' has been cancelled');
+        });
+    }
+
+    private function serializeQueryToIdentity(Query $query)
+    {
+        return sprintf('%s:%s:%s', $query->name, $query->type, $query->class);
+    }
+}

--- a/src/Query/HostsFileExecutor.php
+++ b/src/Query/HostsFileExecutor.php
@@ -8,7 +8,7 @@ use React\Dns\Model\Record;
 use React\Promise;
 
 /**
- * Resolves hosts from the givne HostsFile or falls back to another executor
+ * Resolves hosts from the given HostsFile or falls back to another executor
  *
  * If the host is found in the hosts file, it will not be passed to the actual
  * DNS executor. If the host is not found in the hosts file, it will be passed

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -60,6 +60,26 @@ use React\Promise\Deferred;
  * );
  * ```
  *
+ * Note that this executor is entirely async and as such allows you to execute
+ * any number of queries concurrently. You should probably limit the number of
+ * concurrent queries in your application or you're very likely going to face
+ * rate limitations and bans on the resolver end. For many common applications,
+ * you may want to avoid sending the same query multiple times when the first
+ * one is still pending, so you will likely want to use this in combination with
+ * a `CoopExecutor` like this:
+ *
+ * ```php
+ * $executor = new CoopExecutor(
+ *     new RetryExecutor(
+ *         new TimeoutExecutor(
+ *             new UdpTransportExecutor($loop),
+ *             3.0,
+ *             $loop
+ *         )
+ *     )
+ * );
+ * ```
+ *
  * > Internally, this class uses PHP's UDP sockets and does not take advantage
  *   of [react/datagram](https://github.com/reactphp/datagram) purely for
  *   organizational reasons to avoid a cyclic dependency between the two

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -6,6 +6,7 @@ use React\Cache\ArrayCache;
 use React\Cache\CacheInterface;
 use React\Dns\Config\HostsFile;
 use React\Dns\Query\CachedExecutor;
+use React\Dns\Query\CoopExecutor;
 use React\Dns\Query\ExecutorInterface;
 use React\Dns\Query\HostsFileExecutor;
 use React\Dns\Query\RecordCache;
@@ -77,7 +78,7 @@ class Factory
 
     protected function createRetryExecutor(LoopInterface $loop)
     {
-        return new RetryExecutor($this->createExecutor($loop));
+        return new CoopExecutor(new RetryExecutor($this->createExecutor($loop)));
     }
 
     protected function createCachedExecutor(LoopInterface $loop, CacheInterface $cache)

--- a/tests/Query/CoopExecutorTest.php
+++ b/tests/Query/CoopExecutorTest.php
@@ -1,0 +1,208 @@
+<?php
+
+use React\Dns\Query\CoopExecutor;
+use React\Dns\Model\Message;
+use React\Dns\Query\Query;
+use React\Promise\Promise;
+use React\Tests\Dns\TestCase;
+use React\Promise\Deferred;
+
+class CoopExecutorTest extends TestCase
+{
+    public function testQueryOnceWillPassExactQueryToBaseExecutor()
+    {
+        $pending = new Promise(function () { });
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->once())->method('query')->with('8.8.8.8', $query)->willReturn($pending);
+        $connector = new CoopExecutor($base);
+
+        $connector->query('8.8.8.8', $query);
+    }
+
+    public function testQueryOnceWillResolveWhenBaseExecutorResolves()
+    {
+        $message = new Message();
+
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->once())->method('query')->willReturn(\React\Promise\resolve($message));
+        $connector = new CoopExecutor($base);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $promise = $connector->query('8.8.8.8', $query);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+
+        $promise->then($this->expectCallableOnceWith($message));
+    }
+
+    public function testQueryOnceWillRejectWhenBaseExecutorRejects()
+    {
+        $exception = new RuntimeException();
+
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->once())->method('query')->willReturn(\React\Promise\reject($exception));
+        $connector = new CoopExecutor($base);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $promise = $connector->query('8.8.8.8', $query);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+
+        $promise->then(null, $this->expectCallableOnceWith($exception));
+    }
+
+    public function testQueryTwoDifferentQueriesWillPassExactQueryToBaseExecutorTwice()
+    {
+        $pending = new Promise(function () { });
+        $query1 = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $query2 = new Query('reactphp.org', Message::TYPE_AAAA, Message::CLASS_IN);
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->exactly(2))->method('query')->withConsecutive(
+            array('8.8.8.8', $query1),
+            array('8.8.8.8', $query2)
+        )->willReturn($pending);
+        $connector = new CoopExecutor($base);
+
+        $connector->query('8.8.8.8', $query1);
+        $connector->query('8.8.8.8', $query2);
+    }
+
+    public function testQueryTwiceWillPassExactQueryToBaseExecutorOnceWhenQueryIsStillPending()
+    {
+        $pending = new Promise(function () { });
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->once())->method('query')->with('8.8.8.8', $query)->willReturn($pending);
+        $connector = new CoopExecutor($base);
+
+        $connector->query('8.8.8.8', $query);
+        $connector->query('8.8.8.8', $query);
+    }
+
+    public function testQueryTwiceWillPassExactQueryToBaseExecutorTwiceWhenFirstQueryIsAlreadyResolved()
+    {
+        $deferred = new Deferred();
+        $pending = new Promise(function () { });
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->exactly(2))->method('query')->with('8.8.8.8', $query)->willReturnOnConsecutiveCalls($deferred->promise(), $pending);
+
+        $connector = new CoopExecutor($base);
+
+        $connector->query('8.8.8.8', $query);
+
+        $deferred->resolve(new Message());
+
+        $connector->query('8.8.8.8', $query);
+    }
+
+    public function testQueryTwiceWillPassExactQueryToBaseExecutorTwiceWhenFirstQueryIsAlreadyRejected()
+    {
+        $deferred = new Deferred();
+        $pending = new Promise(function () { });
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->exactly(2))->method('query')->with('8.8.8.8', $query)->willReturnOnConsecutiveCalls($deferred->promise(), $pending);
+
+        $connector = new CoopExecutor($base);
+
+        $connector->query('8.8.8.8', $query);
+
+        $deferred->reject(new RuntimeException());
+
+        $connector->query('8.8.8.8', $query);
+    }
+
+    public function testCancelQueryWillCancelPromiseFromBaseExecutorAndReject()
+    {
+        $promise = new Promise(function () { }, $this->expectCallableOnce());
+
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->once())->method('query')->willReturn($promise);
+        $connector = new CoopExecutor($base);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $promise = $connector->query('8.8.8.8', $query);
+
+        $promise->cancel();
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testCancelOneQueryWhenOtherQueryIsStillPendingWillNotCancelPromiseFromBaseExecutorAndRejectCancelled()
+    {
+        $promise = new Promise(function () { }, $this->expectCallableNever());
+
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->once())->method('query')->willReturn($promise);
+        $connector = new CoopExecutor($base);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $promise1 = $connector->query('8.8.8.8', $query);
+        $promise2 = $connector->query('8.8.8.8', $query);
+
+        $promise1->cancel();
+
+        $promise1->then(null, $this->expectCallableOnce());
+        $promise2->then(null, $this->expectCallableNever());
+    }
+
+    public function testCancelSecondQueryWhenFirstQueryIsStillPendingWillNotCancelPromiseFromBaseExecutorAndRejectCancelled()
+    {
+        $promise = new Promise(function () { }, $this->expectCallableNever());
+
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->once())->method('query')->willReturn($promise);
+        $connector = new CoopExecutor($base);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $promise1 = $connector->query('8.8.8.8', $query);
+        $promise2 = $connector->query('8.8.8.8', $query);
+
+        $promise2->cancel();
+
+        $promise2->then(null, $this->expectCallableOnce());
+        $promise1->then(null, $this->expectCallableNever());
+    }
+
+    public function testCancelAllPendingQueriesWillCancelPromiseFromBaseExecutorAndRejectCancelled()
+    {
+        $promise = new Promise(function () { }, $this->expectCallableOnce());
+
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->once())->method('query')->willReturn($promise);
+        $connector = new CoopExecutor($base);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $promise1 = $connector->query('8.8.8.8', $query);
+        $promise2 = $connector->query('8.8.8.8', $query);
+
+        $promise1->cancel();
+        $promise2->cancel();
+
+        $promise1->then(null, $this->expectCallableOnce());
+        $promise2->then(null, $this->expectCallableOnce());
+    }
+
+    public function testQueryTwiceWillQueryBaseExecutorTwiceIfFirstQueryHasAlreadyBeenCancelledWhenSecondIsStarted()
+    {
+        $promise = new Promise(function () { }, $this->expectCallableOnce());
+        $pending = new Promise(function () { });
+
+        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base->expects($this->exactly(2))->method('query')->willReturnOnConsecutiveCalls($promise, $pending);
+        $connector = new CoopExecutor($base);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $promise1 = $connector->query('8.8.8.8', $query);
+        $promise1->cancel();
+
+        $promise2 = $connector->query('8.8.8.8', $query);
+
+        $promise1->then(null, $this->expectCallableOnce());
+
+        $promise2->then(null, $this->expectCallableNever());
+    }
+}


### PR DESCRIPTION
This PR adds a new `CoopExecutor` which cooperatively resolves hosts via the given base executor to ensure same query is not run concurrently.

This is useful because all executors are entirely async and as such allow you to execute any number of queries concurrently. You should probably limit the number of concurrent queries in your application or you're very likely going to face rate limitations and bans on the resolver end. For many common applications, you may want to avoid sending the same query multiple times when the first one is still pending, so you will likely want to use this in combination with some other executor (which is the new default).

This is best reproduced by using some higher-level protocol implementation, for example it's rather common to send hundreds of (RESTful) HTTP API calls to the same host name, often concurrently. In this case, it doesn't make much sense to send the same DNS query multiple times.

Note that this is not to be confused with caching (which is already implemented to some degree). This PR only deals with avoiding *concurrency* while caching deals with queries that happen *after* a query is already completed.

Here's a synthetic example (`99-excessive.php reactphp.org 1000`) which highlights this low-level API. Benchmarking suggests this example improved from ~390ms down to ~160ms using a local DNS resolver (YMMV).

```php
<?php

use React\Dns\Config\Config;
use React\Dns\Resolver\Factory;

require __DIR__ . '/../vendor/autoload.php';

$loop = React\EventLoop\Factory::create();

$config = Config::loadSystemConfigBlocking();
$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';

$factory = new Factory();
$resolver = $factory->create($server, $loop);

if (!isset($argv[2])) {
    echo 'Usage: ' . $argv[0] . ' <domain> <n>' . PHP_EOL;
    exit(1);
}

$domain = $argv[1];
$n = (int)$argv[2];

echo 'go…';
$ok = $failed = 0;
for ($i = 0; $i < $n; ++$i) {
    $resolver->resolve($domain)->then(function () use (&$ok, &$failed, $n) {
        ++$ok;
        echo "\r" . $ok . '/' . $failed . '/' . $n;
    }, function () use (&$ok, &$failed, $n) {
        ++$failed;
        echo "\r" . $ok . '/' . $failed . '/' . $n;
    });
}

$loop->run();

echo "\r" . $ok . '/' . $failed . '/' . $n . ' done'. PHP_EOL;
```

Closes #90 