### PR TITLE
Implement `CachingExecutor` using cache TTL, deprecate old `CachedExecutor`

### DIFF
--- a/src/Query/CachedExecutor.php
+++ b/src/Query/CachedExecutor.php
@@ -4,6 +4,10 @@ namespace React\Dns\Query;
 
 use React\Dns\Model\Message;
 
+/**
+ * @deprecated unused, exists for BC only
+ * @see CachingExecutor
+ */
 class CachedExecutor implements ExecutorInterface
 {
     private $executor;

--- a/src/Query/CachingExecutor.php
+++ b/src/Query/CachingExecutor.php
@@ -43,8 +43,10 @@ class CachingExecutor implements ExecutorInterface
                     // perform DNS lookup if not already cached
                     return $pending = $executor->query($nameserver, $query)->then(
                         function (Message $message) use ($cache, $id) {
-                            // DNS response message received => store in cache and return
-                            $cache->set($id, $message, CachingExecutor::TTL);
+                            // DNS response message received => store in cache when not truncated and return
+                            if (!$message->header->isTruncated()) {
+                                $cache->set($id, $message, CachingExecutor::TTL);
+                            }
 
                             return $message;
                         }

--- a/src/Query/CachingExecutor.php
+++ b/src/Query/CachingExecutor.php
@@ -4,6 +4,7 @@ namespace React\Dns\Query;
 
 use React\Cache\CacheInterface;
 use React\Dns\Model\Message;
+use React\Promise\Promise;
 
 class CachingExecutor implements ExecutorInterface
 {
@@ -30,21 +31,29 @@ class CachingExecutor implements ExecutorInterface
         $cache = $this->cache;
         $executor = $this->executor;
 
-        return $cache->get($id)->then(function ($message) use ($nameserver, $query, $id, $cache, $executor) {
-            // return cached response message on cache hit
-            if ($message !== null) {
-                return $message;
-            }
+        $pending = $cache->get($id);
+        return new Promise(function ($resolve, $reject) use ($nameserver, $query, $id, $cache, $executor, &$pending) {
+            $pending->then(
+                function ($message) use ($nameserver, $query, $id, $cache, $executor, &$pending) {
+                    // return cached response message on cache hit
+                    if ($message !== null) {
+                        return $message;
+                    }
 
-            // perform DNS lookup if not already cached
-            return $executor->query($nameserver, $query)->then(
-                function (Message $message) use ($cache, $id) {
-                    // DNS response message received => store in cache and return
-                    $cache->set($id, $message, CachingExecutor::TTL);
+                    // perform DNS lookup if not already cached
+                    return $pending = $executor->query($nameserver, $query)->then(
+                        function (Message $message) use ($cache, $id) {
+                            // DNS response message received => store in cache and return
+                            $cache->set($id, $message, CachingExecutor::TTL);
 
-                    return $message;
+                            return $message;
+                        }
+                    );
                 }
-            );
+            )->then($resolve, $reject);
+        }, function ($_, $reject) use (&$pending, $query) {
+            $reject(new \RuntimeException('DNS query for ' . $query->name . ' has been cancelled'));
+            $pending->cancel();
         });
     }
 }

--- a/src/Query/CachingExecutor.php
+++ b/src/Query/CachingExecutor.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace React\Dns\Query;
+
+use React\Cache\CacheInterface;
+use React\Dns\Model\Message;
+
+class CachingExecutor implements ExecutorInterface
+{
+    /**
+     * Initial implementation uses a fixed TTL for postive DNS responses as well
+     * as negative responses (NXDOMAIN etc.).
+     *
+     * @internal
+     */
+    const TTL = 60;
+
+    private $executor;
+    private $cache;
+
+    public function __construct(ExecutorInterface $executor, CacheInterface $cache)
+    {
+        $this->executor = $executor;
+        $this->cache = $cache;
+    }
+
+    public function query($nameserver, Query $query)
+    {
+        $id = $query->name . ':' . $query->type . ':' . $query->class;
+        $cache = $this->cache;
+        $executor = $this->executor;
+
+        return $cache->get($id)->then(function ($message) use ($nameserver, $query, $id, $cache, $executor) {
+            // return cached response message on cache hit
+            if ($message !== null) {
+                return $message;
+            }
+
+            // perform DNS lookup if not already cached
+            return $executor->query($nameserver, $query)->then(
+                function (Message $message) use ($cache, $id) {
+                    // DNS response message received => store in cache and return
+                    $cache->set($id, $message, CachingExecutor::TTL);
+
+                    return $message;
+                }
+            );
+        });
+    }
+}

--- a/src/Query/RecordBag.php
+++ b/src/Query/RecordBag.php
@@ -4,6 +4,10 @@ namespace React\Dns\Query;
 
 use React\Dns\Model\Record;
 
+/**
+ * @deprecated unused, exists for BC only
+ * @see CachingExecutor
+ */
 class RecordBag
 {
     private $records = array();

--- a/src/Query/RecordCache.php
+++ b/src/Query/RecordCache.php
@@ -10,6 +10,9 @@ use React\Promise\PromiseInterface;
 
 /**
  * Wraps an underlying cache interface and exposes only cached DNS data
+ *
+ * @deprecated unused, exists for BC only
+ * @see CachingExecutor
  */
 class RecordCache
 {

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -5,11 +5,10 @@ namespace React\Dns\Resolver;
 use React\Cache\ArrayCache;
 use React\Cache\CacheInterface;
 use React\Dns\Config\HostsFile;
-use React\Dns\Query\CachedExecutor;
+use React\Dns\Query\CachingExecutor;
 use React\Dns\Query\CoopExecutor;
 use React\Dns\Query\ExecutorInterface;
 use React\Dns\Query\HostsFileExecutor;
-use React\Dns\Query\RecordCache;
 use React\Dns\Query\RetryExecutor;
 use React\Dns\Query\TimeoutExecutor;
 use React\Dns\Query\UdpTransportExecutor;
@@ -84,7 +83,7 @@ class Factory
 
     protected function createCachedExecutor(LoopInterface $loop, CacheInterface $cache)
     {
-        return new CachedExecutor($this->createRetryExecutor($loop), new RecordCache($cache));
+        return new CachingExecutor($this->createRetryExecutor($loop), $cache);
     }
 
     protected function addPortToServerIfMissing($nameserver)

--- a/tests/Query/CachingExecutorTest.php
+++ b/tests/Query/CachingExecutorTest.php
@@ -101,8 +101,6 @@ class CachingExecutorTest extends TestCase
 
     public function testCancelQueryWillReturnRejectedPromiseAndCancelPendingPromiseFromCache()
     {
-        $this->markTestIncomplete();
-
         $fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
         $fallback->expects($this->never())->method('query');
 
@@ -122,8 +120,6 @@ class CachingExecutorTest extends TestCase
 
     public function testCancelQueryWillReturnRejectedPromiseAndCancelPendingPromiseFromFallbackExecutorWhenCacheReturnsMiss()
     {
-        $this->markTestIncomplete();
-
         $pending = new Promise(function () { }, $this->expectCallableOnce());
         $fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
         $fallback->expects($this->once())->method('query')->willReturn($pending);

--- a/tests/Query/CachingExecutorTest.php
+++ b/tests/Query/CachingExecutorTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace React\Tests\Dns\Query;
+
+use React\Dns\Model\Message;
+use React\Dns\Query\CachingExecutor;
+use React\Dns\Query\Query;
+use React\Promise\Promise;
+use React\Tests\Dns\TestCase;
+use React\Promise\Deferred;
+
+class CachingExecutorTest extends TestCase
+{
+    public function testQueryWillReturnPendingPromiseWhenCacheIsPendingWithoutSendingQueryToFallbackExecutor()
+    {
+        $fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $fallback->expects($this->never())->method('query');
+
+        $cache = $this->getMockBuilder('React\Cache\CacheInterface')->getMock();
+        $cache->expects($this->once())->method('get')->with('reactphp.org:1:1')->willReturn(new Promise(function () { }));
+
+        $executor = new CachingExecutor($fallback, $cache);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $promise = $executor->query('8.8.8.8', $query);
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableNever());
+    }
+
+    public function testQueryWillReturnPendingPromiseWhenCacheReturnsMissAndWillSendSameQueryToFallbackExecutor()
+    {
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $fallback->expects($this->once())->method('query')->with('8.8.8.8', $query)->willReturn(new Promise(function () { }));
+
+        $cache = $this->getMockBuilder('React\Cache\CacheInterface')->getMock();
+        $cache->expects($this->once())->method('get')->willReturn(\React\Promise\resolve(null));
+
+        $executor = new CachingExecutor($fallback, $cache);
+
+        $promise = $executor->query('8.8.8.8', $query);
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableNever());
+    }
+
+    public function testQueryWillReturnResolvedPromiseWhenCacheReturnsHitWithoutSendingQueryToFallbackExecutor()
+    {
+        $fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $fallback->expects($this->never())->method('query');
+
+        $message = new Message();
+        $cache = $this->getMockBuilder('React\Cache\CacheInterface')->getMock();
+        $cache->expects($this->once())->method('get')->with('reactphp.org:1:1')->willReturn(\React\Promise\resolve($message));
+
+        $executor = new CachingExecutor($fallback, $cache);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $promise = $executor->query('8.8.8.8', $query);
+
+        $promise->then($this->expectCallableOnceWith($message), $this->expectCallableNever());
+    }
+
+    public function testQueryWillReturnResolvedPromiseWhenCacheReturnsMissAndFallbackExecutorResolvesAndSaveMessageToCache()
+    {
+        $message = new Message();
+        $fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $fallback->expects($this->once())->method('query')->willReturn(\React\Promise\resolve($message));
+
+        $cache = $this->getMockBuilder('React\Cache\CacheInterface')->getMock();
+        $cache->expects($this->once())->method('get')->with('reactphp.org:1:1')->willReturn(\React\Promise\resolve(null));
+        $cache->expects($this->once())->method('set')->with('reactphp.org:1:1', $message, 60);
+
+        $executor = new CachingExecutor($fallback, $cache);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $promise = $executor->query('8.8.8.8', $query);
+
+        $promise->then($this->expectCallableOnceWith($message), $this->expectCallableNever());
+    }
+
+    public function testQueryWillReturnRejectedPromiseWhenCacheReturnsMissAndFallbackExecutorRejects()
+    {
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $fallback->expects($this->once())->method('query')->willReturn(\React\Promise\reject(new \RuntimeException()));
+
+        $cache = $this->getMockBuilder('React\Cache\CacheInterface')->getMock();
+        $cache->expects($this->once())->method('get')->willReturn(\React\Promise\resolve(null));
+
+        $executor = new CachingExecutor($fallback, $cache);
+
+        $promise = $executor->query('8.8.8.8', $query);
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
+    }
+
+    public function testCancelQueryWillReturnRejectedPromiseAndCancelPendingPromiseFromCache()
+    {
+        $this->markTestIncomplete();
+
+        $fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $fallback->expects($this->never())->method('query');
+
+        $pending = new Promise(function () { }, $this->expectCallableOnce());
+        $cache = $this->getMockBuilder('React\Cache\CacheInterface')->getMock();
+        $cache->expects($this->once())->method('get')->with('reactphp.org:1:1')->willReturn($pending);
+
+        $executor = new CachingExecutor($fallback, $cache);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $promise = $executor->query('8.8.8.8', $query);
+        $promise->cancel();
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
+    }
+
+    public function testCancelQueryWillReturnRejectedPromiseAndCancelPendingPromiseFromFallbackExecutorWhenCacheReturnsMiss()
+    {
+        $this->markTestIncomplete();
+
+        $pending = new Promise(function () { }, $this->expectCallableOnce());
+        $fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $fallback->expects($this->once())->method('query')->willReturn($pending);
+
+        $deferred = new Deferred();
+        $cache = $this->getMockBuilder('React\Cache\CacheInterface')->getMock();
+        $cache->expects($this->once())->method('get')->with('reactphp.org:1:1')->willReturn($deferred->promise());
+
+        $executor = new CachingExecutor($fallback, $cache);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $promise = $executor->query('8.8.8.8', $query);
+        $deferred->resolve(null);
+        $promise->cancel();
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
+    }
+}

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -32,7 +32,7 @@ class FactoryTest extends TestCase
     }
 
     /** @test */
-    public function createCachedShouldCreateResolverWithCachedExecutor()
+    public function createCachedShouldCreateResolverWithCachingExecutor()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -41,15 +41,13 @@ class FactoryTest extends TestCase
 
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
         $executor = $this->getResolverPrivateExecutor($resolver);
-        $this->assertInstanceOf('React\Dns\Query\CachedExecutor', $executor);
-        $recordCache = $this->getCachedExecutorPrivateMemberValue($executor, 'cache');
-        $recordCacheCache = $this->getRecordCachePrivateMemberValue($recordCache, 'cache');
-        $this->assertInstanceOf('React\Cache\CacheInterface', $recordCacheCache);
-        $this->assertInstanceOf('React\Cache\ArrayCache', $recordCacheCache);
+        $this->assertInstanceOf('React\Dns\Query\CachingExecutor', $executor);
+        $cache = $this->getCachingExecutorPrivateMemberValue($executor, 'cache');
+        $this->assertInstanceOf('React\Cache\ArrayCache', $cache);
     }
 
     /** @test */
-    public function createCachedShouldCreateResolverWithCachedExecutorWithCustomCache()
+    public function createCachedShouldCreateResolverWithCachingExecutorWithCustomCache()
     {
         $cache = $this->getMockBuilder('React\Cache\CacheInterface')->getMock();
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -59,11 +57,9 @@ class FactoryTest extends TestCase
 
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
         $executor = $this->getResolverPrivateExecutor($resolver);
-        $this->assertInstanceOf('React\Dns\Query\CachedExecutor', $executor);
-        $recordCache = $this->getCachedExecutorPrivateMemberValue($executor, 'cache');
-        $recordCacheCache = $this->getRecordCachePrivateMemberValue($recordCache, 'cache');
-        $this->assertInstanceOf('React\Cache\CacheInterface', $recordCacheCache);
-        $this->assertSame($cache, $recordCacheCache);
+        $this->assertInstanceOf('React\Dns\Query\CachingExecutor', $executor);
+        $cacheProperty = $this->getCachingExecutorPrivateMemberValue($executor, 'cache');
+        $this->assertSame($cache, $cacheProperty);
     }
 
     /**
@@ -115,16 +111,9 @@ class FactoryTest extends TestCase
         return $reflector->getValue($resolver);
     }
 
-    private function getCachedExecutorPrivateMemberValue($resolver, $field)
+    private function getCachingExecutorPrivateMemberValue($resolver, $field)
     {
-        $reflector = new \ReflectionProperty('React\Dns\Query\CachedExecutor', $field);
-        $reflector->setAccessible(true);
-        return $reflector->getValue($resolver);
-    }
-
-    private function getRecordCachePrivateMemberValue($resolver, $field)
-    {
-        $reflector = new \ReflectionProperty('React\Dns\Query\RecordCache', $field);
+        $reflector = new \ReflectionProperty('React\Dns\Query\CachingExecutor', $field);
         $reflector->setAccessible(true);
         return $reflector->getValue($resolver);
     }


### PR DESCRIPTION
This PR implements a whole new `CachingExecutor` and deprecates the existing `CachedExecutor` because it is broken beyond repair. As part of this changeset, we now ensure that we cache the whole respone message including all records from the RRset (fxies #119). Additionally, we no longer cache truncated response messages as per the RFC.

~This initial implements always uses a 60s cache TTL for each response message, irrespective of the TTL indicated for each record (see #81). We believe this is a reasonable compromise as an initial version that should not affect most common use cases. A follow-up PR should implement a more sophisticated TTL logic in the future and should respect the TTL values for each record (within reasonable limits as discussed in #81 and #116).~
This implements now respects the TTL indicated for each record (see #81) and uses a 60s cache TTL for negative messages.

Resolves #119 
Resolves #81 
Builds on top of #127 