### PR TITLE
Avoid garbage references when DNS resolution rejects on legacy PHP <= 5.6

### DIFF
--- a/src/Query/CachingExecutor.php
+++ b/src/Query/CachingExecutor.php
@@ -52,10 +52,14 @@ class CachingExecutor implements ExecutorInterface
                         }
                     );
                 }
-            )->then($resolve, $reject);
+            )->then($resolve, function ($e) use ($reject, &$pending) {
+                $reject($e);
+                $pending = null;
+            });
         }, function ($_, $reject) use (&$pending, $query) {
             $reject(new \RuntimeException('DNS query for ' . $query->name . ' has been cancelled'));
             $pending->cancel();
+            $pending = null;
         });
     }
 

--- a/src/Query/CoopExecutor.php
+++ b/src/Query/CoopExecutor.php
@@ -75,10 +75,11 @@ class CoopExecutor implements ExecutorInterface
         $counts =& $this->counts;
         return new Promise(function ($resolve, $reject) use ($promise) {
             $promise->then($resolve, $reject);
-        }, function () use ($promise, $key, $query, &$pending, &$counts) {
+        }, function () use (&$promise, $key, $query, &$pending, &$counts) {
             if (--$counts[$key] < 1) {
                 unset($pending[$key], $counts[$key]);
                 $promise->cancel();
+                $promise = null;
             }
             throw new \RuntimeException('DNS query for ' . $query->name . ' has been cancelled');
         });

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -98,4 +98,74 @@ class FunctionalTest extends TestCase
         $promise = $this->resolver->resolve('google.com');
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
     }
+
+    public function testResolveShouldNotCauseGarbageReferencesWhenUsingInvalidNameserver()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        $factory = new Factory();
+        $this->resolver = $factory->create('255.255.255.255', $this->loop);
+
+        gc_collect_cycles();
+
+        $promise = $this->resolver->resolve('google.com');
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testResolveCachedShouldNotCauseGarbageReferencesWhenUsingInvalidNameserver()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        $factory = new Factory();
+        $this->resolver = $factory->createCached('255.255.255.255', $this->loop);
+
+        gc_collect_cycles();
+
+        $promise = $this->resolver->resolve('google.com');
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testCancelResolveShouldNotCauseGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        $factory = new Factory();
+        $this->resolver = $factory->create('127.0.0.1', $this->loop);
+
+        gc_collect_cycles();
+
+        $promise = $this->resolver->resolve('google.com');
+        $promise->cancel();
+        $promise = null;
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testCancelResolveCachedShouldNotCauseGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        $factory = new Factory();
+        $this->resolver = $factory->createCached('127.0.0.1', $this->loop);
+
+        gc_collect_cycles();
+
+        $promise = $this->resolver->resolve('google.com');
+        $promise->cancel();
+        $promise = null;
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
 }


### PR DESCRIPTION
These garbage references only show up when a DNS lookup rejects with an
Exception on legacy PHP <= 5.6. These issues have been fixed upstream in
the Promise component for current PHP versions with
https://github.com/reactphp/promise/releases/tag/v2.6.0 but this PR
explicitly unsets known garbage references to avoid unexpected memory
growth on legacy PHP versions.

The downstream Socket component implicitly depends on this because its
test suite currently fails. This changeset can be considered a new
feature in this component which fixes a bug in the test suite of a
downstream component.

Accordingly to the roadmap (https://github.com/reactphp/dns/issues/128) we planned to stop the v0.4.x series, but I consider this to be a notable issue that warrants a v0.4.19 release. Once accepted, I will manually merge this into the current `master` branch targeting the upcoming `v1.0.0` milestone.

Builds on top of #125 and #129
Refs #118