### PR TITLE
Mark all classes as final to discourage inheritance

### DIFF
--- a/src/BadServerException.php
+++ b/src/BadServerException.php
@@ -2,6 +2,6 @@
 
 namespace React\Dns;
 
-class BadServerException extends \Exception
+final class BadServerException extends \Exception
 {
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -4,7 +4,7 @@ namespace React\Dns\Config;
 
 use RuntimeException;
 
-class Config
+final class Config
 {
     /**
      * Loads the system DNS configuration

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -9,7 +9,7 @@ use React\Dns\Query\Query;
  *
  * @link https://tools.ietf.org/html/rfc1035#section-4.1.1
  */
-class Message
+final class Message
 {
     const TYPE_A = 1;
     const TYPE_NS = 2;

--- a/src/Model/Record.php
+++ b/src/Model/Record.php
@@ -11,7 +11,7 @@ namespace React\Dns\Model;
  * @link https://tools.ietf.org/html/rfc1035#section-4.1.3
  * @see \React\Dns\Query\Query
  */
-class Record
+final class Record
 {
     /**
      * @var string hostname without trailing dot, for example "reactphp.org"

--- a/src/Protocol/BinaryDumper.php
+++ b/src/Protocol/BinaryDumper.php
@@ -6,7 +6,7 @@ use React\Dns\Model\Message;
 use React\Dns\Model\Record;
 use React\Dns\Query\Query;
 
-class BinaryDumper
+final class BinaryDumper
 {
     /**
      * @param Message $message

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -12,7 +12,7 @@ use InvalidArgumentException;
  *
  * Obsolete and uncommon types and classes are not implemented.
  */
-class Parser
+final class Parser
 {
     /**
      * Parses the given raw binary message into a Message object

--- a/src/Query/CachingExecutor.php
+++ b/src/Query/CachingExecutor.php
@@ -6,7 +6,7 @@ use React\Cache\CacheInterface;
 use React\Dns\Model\Message;
 use React\Promise\Promise;
 
-class CachingExecutor implements ExecutorInterface
+final class CachingExecutor implements ExecutorInterface
 {
     /**
      * Default TTL for negative responses (NXDOMAIN etc.).

--- a/src/Query/CancellationException.php
+++ b/src/Query/CancellationException.php
@@ -2,6 +2,6 @@
 
 namespace React\Dns\Query;
 
-class CancellationException extends \RuntimeException
+final class CancellationException extends \RuntimeException
 {
 }

--- a/src/Query/CoopExecutor.php
+++ b/src/Query/CoopExecutor.php
@@ -35,7 +35,7 @@ use React\Promise\Promise;
  * );
  * ```
  */
-class CoopExecutor implements ExecutorInterface
+final class CoopExecutor implements ExecutorInterface
 {
     private $executor;
     private $pending = array();

--- a/src/Query/HostsFileExecutor.php
+++ b/src/Query/HostsFileExecutor.php
@@ -14,7 +14,7 @@ use React\Promise;
  * DNS executor. If the host is not found in the hosts file, it will be passed
  * to the DNS executor as a fallback.
  */
-class HostsFileExecutor implements ExecutorInterface
+final class HostsFileExecutor implements ExecutorInterface
 {
     private $hosts;
     private $fallback;

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -11,7 +11,7 @@ namespace React\Dns\Query;
  * @link https://tools.ietf.org/html/rfc1035#section-4.1.2
  * @see \React\Dns\Message\Record
  */
-class Query
+final class Query
 {
     /**
      * @var string query name, i.e. hostname to look up

--- a/src/Query/RetryExecutor.php
+++ b/src/Query/RetryExecutor.php
@@ -5,7 +5,7 @@ namespace React\Dns\Query;
 use React\Promise\CancellablePromiseInterface;
 use React\Promise\Deferred;
 
-class RetryExecutor implements ExecutorInterface
+final class RetryExecutor implements ExecutorInterface
 {
     private $executor;
     private $retries;

--- a/src/Query/TimeoutException.php
+++ b/src/Query/TimeoutException.php
@@ -2,6 +2,6 @@
 
 namespace React\Dns\Query;
 
-class TimeoutException extends \Exception
+final class TimeoutException extends \Exception
 {
 }

--- a/src/Query/TimeoutExecutor.php
+++ b/src/Query/TimeoutExecutor.php
@@ -7,7 +7,7 @@ use React\Promise\Deferred;
 use React\Promise\CancellablePromiseInterface;
 use React\Promise\Timer;
 
-class TimeoutExecutor implements ExecutorInterface
+final class TimeoutExecutor implements ExecutorInterface
 {
     private $executor;
     private $loop;

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -85,7 +85,7 @@ use React\Promise\Deferred;
  *   packages. Higher-level components should take advantage of the Datagram
  *   component instead of reimplementing this socket logic from scratch.
  */
-class UdpTransportExecutor implements ExecutorInterface
+final class UdpTransportExecutor implements ExecutorInterface
 {
     private $loop;
     private $parser;

--- a/src/RecordNotFoundException.php
+++ b/src/RecordNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace React\Dns;
 
-class RecordNotFoundException extends \Exception
+final class RecordNotFoundException extends \Exception
 {
 }

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -14,7 +14,7 @@ use React\Dns\Query\TimeoutExecutor;
 use React\Dns\Query\UdpTransportExecutor;
 use React\EventLoop\LoopInterface;
 
-class Factory
+final class Factory
 {
     public function create($nameserver, LoopInterface $loop)
     {

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -8,7 +8,7 @@ use React\Dns\Query\Query;
 use React\Dns\RecordNotFoundException;
 use React\Promise\PromiseInterface;
 
-class Resolver
+final class Resolver
 {
     private $executor;
 


### PR DESCRIPTION
Classes should be used via composition rather than extension.
This reduces our API footprint and avoids future BC breaks by avoiding
exposing its internal assumptions.