### PR TITLE
Mark all Record attributes as required, add documentation vs Query

### DIFF
--- a/src/Model/Record.php
+++ b/src/Model/Record.php
@@ -2,6 +2,15 @@
 
 namespace React\Dns\Model;
 
+/**
+ * This class represents a single resulting record in a response message
+ *
+ * It uses a structure similar to `\React\Dns\Query\Query`, but does include
+ * fields for resulting TTL and resulting record data (IPs etc.).
+ *
+ * @link https://tools.ietf.org/html/rfc1035#section-4.1.3
+ * @see \React\Dns\Query\Query
+ */
 class Record
 {
     /**
@@ -94,7 +103,7 @@ class Record
      * @param int                   $ttl
      * @param string|string[]|array $data
      */
-    public function __construct($name, $type, $class, $ttl = 0, $data = null)
+    public function __construct($name, $type, $class, $ttl, $data)
     {
         $this->name     = $name;
         $this->type     = $type;

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -2,10 +2,30 @@
 
 namespace React\Dns\Query;
 
+/**
+ * This class represents a single question in a query/response message
+ *
+ * It uses a structure similar to `\React\Dns\Message\Record`, but does not
+ * contain fields for resulting TTL and resulting record data (IPs etc.).
+ *
+ * @link https://tools.ietf.org/html/rfc1035#section-4.1.2
+ * @see \React\Dns\Message\Record
+ */
 class Query
 {
+    /**
+     * @var string query name, i.e. hostname to look up
+     */
     public $name;
+
+    /**
+     * @var int query type (aka QTYPE), see Message::TYPE_* constants
+     */
     public $type;
+
+    /**
+     * @var int query class (aka QCLASS), see Message::CLASS_IN constant
+     */
     public $class;
 
     /**

--- a/tests/Query/RetryExecutorTest.php
+++ b/tests/Query/RetryExecutorTest.php
@@ -340,7 +340,7 @@ class RetryExecutorTest extends TestCase
     {
         $response = new Message();
         $response->qr = true;
-        $response->questions[] = new Record('igor.io', Message::TYPE_A, Message::CLASS_IN);
+        $response->questions[] = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
         $response->answers[] = new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131');
 
         return $response;

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -23,7 +23,7 @@ class ResolverTest extends TestCase
             ->will($this->returnCallback(function ($nameserver, $query) {
                 $response = new Message();
                 $response->qr = true;
-                $response->questions[] = new Record($query->name, $query->type, $query->class);
+                $response->questions[] = new Query($query->name, $query->type, $query->class);
                 $response->answers[] = new Record($query->name, $query->type, $query->class, 3600, '178.79.169.131');
 
                 return Promise\resolve($response);
@@ -44,7 +44,7 @@ class ResolverTest extends TestCase
             ->will($this->returnCallback(function ($nameserver, $query) {
                 $response = new Message();
                 $response->qr = true;
-                $response->questions[] = new Record($query->name, $query->type, $query->class);
+                $response->questions[] = new Query($query->name, $query->type, $query->class);
                 $response->answers[] = new Record($query->name, $query->type, $query->class, 3600, '::1');
 
                 return Promise\resolve($response);
@@ -65,7 +65,7 @@ class ResolverTest extends TestCase
             ->will($this->returnCallback(function ($nameserver, $query) {
                 $response = new Message();
                 $response->qr = true;
-                $response->questions[] = new Record($query->name, $query->type, $query->class);
+                $response->questions[] = new Query($query->name, $query->type, $query->class);
                 $response->answers[] = new Record($query->name, Message::TYPE_TXT, $query->class, 3600, array('ignored'));
                 $response->answers[] = new Record($query->name, $query->type, $query->class, 3600, '::1');
 
@@ -87,7 +87,7 @@ class ResolverTest extends TestCase
             ->will($this->returnCallback(function ($nameserver, $query) {
                 $response = new Message();
                 $response->qr = true;
-                $response->questions[] = new Record($query->name, $query->type, $query->class);
+                $response->questions[] = new Query($query->name, $query->type, $query->class);
                 $response->answers[] = new Record($query->name, Message::TYPE_CNAME, $query->class, 3600, 'example.com');
                 $response->answers[] = new Record('example.com', $query->type, $query->class, 3600, '::1');
                 $response->answers[] = new Record('example.com', $query->type, $query->class, 3600, '::2');
@@ -112,7 +112,7 @@ class ResolverTest extends TestCase
             ->will($this->returnCallback(function ($nameserver, $query) {
                 $response = new Message();
                 $response->qr = true;
-                $response->questions[] = new Record('Blog.wyrihaximus.net', $query->type, $query->class);
+                $response->questions[] = new Query('Blog.wyrihaximus.net', $query->type, $query->class);
                 $response->answers[] = new Record('Blog.wyrihaximus.net', $query->type, $query->class, 3600, '178.79.169.131');
 
                 return Promise\resolve($response);
@@ -133,7 +133,7 @@ class ResolverTest extends TestCase
             ->will($this->returnCallback(function ($nameserver, $query) {
                 $response = new Message();
                 $response->qr = true;
-                $response->questions[] = new Record($query->name, $query->type, $query->class);
+                $response->questions[] = new Query($query->name, $query->type, $query->class);
                 $response->answers[] = new Record('foo.bar', $query->type, $query->class, 3600, '178.79.169.131');
 
                 return Promise\resolve($response);
@@ -158,7 +158,7 @@ class ResolverTest extends TestCase
             ->will($this->returnCallback(function ($nameserver, $query) {
                 $response = new Message();
                 $response->qr = true;
-                $response->questions[] = new Record($query->name, $query->type, $query->class);
+                $response->questions[] = new Query($query->name, $query->type, $query->class);
 
                 return Promise\resolve($response);
             }));
@@ -216,7 +216,7 @@ class ResolverTest extends TestCase
                 $response = new Message();
                 $response->qr = true;
                 $response->rcode = $code;
-                $response->questions[] = new Record($query->name, $query->type, $query->class);
+                $response->questions[] = new Query($query->name, $query->type, $query->class);
 
                 return Promise\resolve($response);
             }));


### PR DESCRIPTION
This changeset marks all `Record` attributes as required attributes in its constructor. Additionally, it adds some documentation for `Record` and `Query` and the fact that they're not the same. These APIs are somewhat internal and it's very unlikely this will affect many consumers of this package.

Builds on top of #130
Refs #128