### PR TITLE
API documentation for ExecutorInterface 

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,9 @@ The following example looks up the `IPv6` address for `igor.io`.
 
 ```php
 $loop = Factory::create();
-$executor = new UdpTransportExecutor($loop);
+$executor = new UdpTransportExecutor('8.8.8.8:53', $loop);
 
 $executor->query(
-    '8.8.8.8:53', 
     new Query($name, Message::TYPE_AAAA, Message::CLASS_IN)
 )->then(function (Message $message) {
     foreach ($message->answers as $answer) {
@@ -229,7 +228,7 @@ want to use this in combination with a `TimeoutExecutor` like this:
 
 ```php
 $executor = new TimeoutExecutor(
-    new UdpTransportExecutor($loop),
+    new UdpTransportExecutor($nameserver, $loop),
     3.0,
     $loop
 );
@@ -242,7 +241,7 @@ combination with a `RetryExecutor` like this:
 ```php
 $executor = new RetryExecutor(
     new TimeoutExecutor(
-        new UdpTransportExecutor($loop),
+        new UdpTransportExecutor($nameserver, $loop),
         3.0,
         $loop
     )
@@ -261,7 +260,7 @@ a `CoopExecutor` like this:
 $executor = new CoopExecutor(
     new RetryExecutor(
         new TimeoutExecutor(
-            new UdpTransportExecutor($loop),
+            new UdpTransportExecutor($nameserver, $loop),
             3.0,
             $loop
         )
@@ -284,11 +283,10 @@ use this code:
 ```php
 $hosts = \React\Dns\Config\HostsFile::loadFromPathBlocking();
 
-$executor = new UdpTransportExecutor($loop);
+$executor = new UdpTransportExecutor('8.8.8.8:53', $loop);
 $executor = new HostsFileExecutor($hosts, $executor);
 
 $executor->query(
-    '8.8.8.8:53', 
     new Query('localhost', Message::TYPE_A, Message::CLASS_IN)
 );
 ```

--- a/examples/91-query-a-and-aaaa.php
+++ b/examples/91-query-a-and-aaaa.php
@@ -8,19 +8,19 @@ use React\EventLoop\Factory;
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$executor = new UdpTransportExecutor($loop);
+$executor = new UdpTransportExecutor('8.8.8.8:53', $loop);
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 
 $ipv4Query = new Query($name, Message::TYPE_A, Message::CLASS_IN);
 $ipv6Query = new Query($name, Message::TYPE_AAAA, Message::CLASS_IN);
 
-$executor->query('8.8.8.8:53', $ipv4Query)->then(function (Message $message) {
+$executor->query($ipv4Query)->then(function (Message $message) {
     foreach ($message->answers as $answer) {
         echo 'IPv4: ' . $answer->data . PHP_EOL;
     }
 }, 'printf');
-$executor->query('8.8.8.8:53', $ipv6Query)->then(function (Message $message) {
+$executor->query($ipv6Query)->then(function (Message $message) {
     foreach ($message->answers as $answer) {
         echo 'IPv6: ' . $answer->data . PHP_EOL;
     }

--- a/examples/92-query-any.php
+++ b/examples/92-query-any.php
@@ -9,13 +9,13 @@ use React\EventLoop\Factory;
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$executor = new UdpTransportExecutor($loop);
+$executor = new UdpTransportExecutor('8.8.8.8:53', $loop);
 
 $name = isset($argv[1]) ? $argv[1] : 'google.com';
 
 $any = new Query($name, Message::TYPE_ANY, Message::CLASS_IN);
 
-$executor->query('8.8.8.8:53', $any)->then(function (Message $message) {
+$executor->query($any)->then(function (Message $message) {
     foreach ($message->answers as $answer) {
         /* @var $answer Record */
 

--- a/src/Query/CachingExecutor.php
+++ b/src/Query/CachingExecutor.php
@@ -24,7 +24,7 @@ class CachingExecutor implements ExecutorInterface
         $this->cache = $cache;
     }
 
-    public function query($nameserver, Query $query)
+    public function query(Query $query)
     {
         $id = $query->name . ':' . $query->type . ':' . $query->class;
         $cache = $this->cache;
@@ -32,16 +32,16 @@ class CachingExecutor implements ExecutorInterface
         $executor = $this->executor;
 
         $pending = $cache->get($id);
-        return new Promise(function ($resolve, $reject) use ($nameserver, $query, $id, $cache, $executor, &$pending, $that) {
+        return new Promise(function ($resolve, $reject) use ($query, $id, $cache, $executor, &$pending, $that) {
             $pending->then(
-                function ($message) use ($nameserver, $query, $id, $cache, $executor, &$pending, $that) {
+                function ($message) use ($query, $id, $cache, $executor, &$pending, $that) {
                     // return cached response message on cache hit
                     if ($message !== null) {
                         return $message;
                     }
 
                     // perform DNS lookup if not already cached
-                    return $pending = $executor->query($nameserver, $query)->then(
+                    return $pending = $executor->query($query)->then(
                         function (Message $message) use ($cache, $id, $that) {
                             // DNS response message received => store in cache when not truncated and return
                             if (!$message->tc) {

--- a/src/Query/CoopExecutor.php
+++ b/src/Query/CoopExecutor.php
@@ -27,7 +27,7 @@ use React\Promise\Promise;
  * $executor = new CoopExecutor(
  *     new RetryExecutor(
  *         new TimeoutExecutor(
- *             new UdpTransportExecutor($loop),
+ *             new UdpTransportExecutor($nameserver, $loop),
  *             3.0,
  *             $loop
  *         )
@@ -46,7 +46,7 @@ class CoopExecutor implements ExecutorInterface
         $this->executor = $base;
     }
 
-    public function query($nameserver, Query $query)
+    public function query(Query $query)
     {
         $key = $this->serializeQueryToIdentity($query);
         if (isset($this->pending[$key])) {
@@ -55,7 +55,7 @@ class CoopExecutor implements ExecutorInterface
             ++$this->counts[$key];
         } else {
             // no such query pending, so start new query and keep reference until it's fulfilled or rejected
-            $promise = $this->executor->query($nameserver, $query);
+            $promise = $this->executor->query($query);
             $this->pending[$key] = $promise;
             $this->counts[$key] = 1;
 

--- a/src/Query/ExecutorInterface.php
+++ b/src/Query/ExecutorInterface.php
@@ -4,5 +4,5 @@ namespace React\Dns\Query;
 
 interface ExecutorInterface
 {
-    public function query($nameserver, Query $query);
+    public function query(Query $query);
 }

--- a/src/Query/ExecutorInterface.php
+++ b/src/Query/ExecutorInterface.php
@@ -4,5 +4,40 @@ namespace React\Dns\Query;
 
 interface ExecutorInterface
 {
+    /**
+     * Executes a query and will return a response message
+     *
+     * It returns a Promise which either fulfills with a response
+     * `React\Dns\Model\Message` on success or rejects with an `Exception` if
+     * the query is not successful. A response message may indicate an error
+     * condition in its `rcode`, but this is considered a valid response message.
+     *
+     * ```php
+     * $executor->query($query)->then(
+     *     function (React\Dns\Model\Message $response) {
+     *         // response message successfully received
+     *         var_dump($response->rcode, $response->answers);
+     *     },
+     *     function (Exception $error) {
+     *         // failed to query due to $error
+     *     }
+     * );
+     * ```
+     *
+     * The returned Promise MUST be implemented in such a way that it can be
+     * cancelled when it is still pending. Cancelling a pending promise MUST
+     * reject its value with an Exception. It SHOULD clean up any underlying
+     * resources and references as applicable.
+     *
+     * ```php
+     * $promise = $executor->query($query);
+     *
+     * $promise->cancel();
+     * ```
+     *
+     * @param Query $query
+     * @return \React\Promise\PromiseInterface<\React\Dns\Model\Message,\Exception>
+     *     resolves with response message on success or rejects with an Exception on error
+     */
     public function query(Query $query);
 }

--- a/src/Query/HostsFileExecutor.php
+++ b/src/Query/HostsFileExecutor.php
@@ -25,7 +25,7 @@ class HostsFileExecutor implements ExecutorInterface
         $this->fallback = $fallback;
     }
 
-    public function query($nameserver, Query $query)
+    public function query(Query $query)
     {
         if ($query->class === Message::CLASS_IN && ($query->type === Message::TYPE_A || $query->type === Message::TYPE_AAAA)) {
             // forward lookup for type A or AAAA
@@ -61,7 +61,7 @@ class HostsFileExecutor implements ExecutorInterface
             }
         }
 
-        return $this->fallback->query($nameserver, $query);
+        return $this->fallback->query($query);
     }
 
     private function getIpFromHost($host)

--- a/src/Query/RetryExecutor.php
+++ b/src/Query/RetryExecutor.php
@@ -16,12 +16,12 @@ class RetryExecutor implements ExecutorInterface
         $this->retries = $retries;
     }
 
-    public function query($nameserver, Query $query)
+    public function query(Query $query)
     {
-        return $this->tryQuery($nameserver, $query, $this->retries);
+        return $this->tryQuery($query, $this->retries);
     }
 
-    public function tryQuery($nameserver, Query $query, $retries)
+    public function tryQuery(Query $query, $retries)
     {
         $deferred = new Deferred(function () use (&$promise) {
             if ($promise instanceof CancellablePromiseInterface) {
@@ -35,7 +35,7 @@ class RetryExecutor implements ExecutorInterface
         };
 
         $executor = $this->executor;
-        $errorback = function ($e) use ($deferred, &$promise, $nameserver, $query, $success, &$errorback, &$retries, $executor) {
+        $errorback = function ($e) use ($deferred, &$promise, $query, $success, &$errorback, &$retries, $executor) {
             if (!$e instanceof TimeoutException) {
                 $errorback = null;
                 $deferred->reject($e);
@@ -62,14 +62,14 @@ class RetryExecutor implements ExecutorInterface
                 $r->setValue($e, $trace);
             } else {
                 --$retries;
-                $promise = $executor->query($nameserver, $query)->then(
+                $promise = $executor->query($query)->then(
                     $success,
                     $errorback
                 );
             }
         };
 
-        $promise = $this->executor->query($nameserver, $query)->then(
+        $promise = $this->executor->query($query)->then(
             $success,
             $errorback
         );

--- a/src/Query/TimeoutExecutor.php
+++ b/src/Query/TimeoutExecutor.php
@@ -20,9 +20,9 @@ class TimeoutExecutor implements ExecutorInterface
         $this->timeout = $timeout;
     }
 
-    public function query($nameserver, Query $query)
+    public function query(Query $query)
     {
-        return Timer\timeout($this->executor->query($nameserver, $query), $this->timeout, $this->loop)->then(null, function ($e) use ($query) {
+        return Timer\timeout($this->executor->query($query), $this->timeout, $this->loop)->then(null, function ($e) use ($query) {
             if ($e instanceof Timer\TimeoutException) {
                 $e = new TimeoutException(sprintf("DNS query for %s timed out", $query->name), 0, $e);
             }

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -10,12 +10,10 @@ use React\Promise\PromiseInterface;
 
 class Resolver
 {
-    private $nameserver;
     private $executor;
 
-    public function __construct($nameserver, ExecutorInterface $executor)
+    public function __construct(ExecutorInterface $executor)
     {
-        $this->nameserver = $nameserver;
         $this->executor = $executor;
     }
 
@@ -116,7 +114,6 @@ class Resolver
         $that = $this;
 
         return $this->executor->query(
-            $this->nameserver,
             $query
         )->then(function (Message $response) use ($query, $that) {
             return $that->extractValues($query, $response);

--- a/tests/Query/CachingExecutorTest.php
+++ b/tests/Query/CachingExecutorTest.php
@@ -24,7 +24,7 @@ class CachingExecutorTest extends TestCase
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $promise = $executor->query('8.8.8.8', $query);
+        $promise = $executor->query($query);
 
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
     }
@@ -34,14 +34,14 @@ class CachingExecutorTest extends TestCase
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
         $fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $fallback->expects($this->once())->method('query')->with('8.8.8.8', $query)->willReturn(new Promise(function () { }));
+        $fallback->expects($this->once())->method('query')->with($query)->willReturn(new Promise(function () { }));
 
         $cache = $this->getMockBuilder('React\Cache\CacheInterface')->getMock();
         $cache->expects($this->once())->method('get')->willReturn(\React\Promise\resolve(null));
 
         $executor = new CachingExecutor($fallback, $cache);
 
-        $promise = $executor->query('8.8.8.8', $query);
+        $promise = $executor->query($query);
 
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
     }
@@ -59,7 +59,7 @@ class CachingExecutorTest extends TestCase
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $promise = $executor->query('8.8.8.8', $query);
+        $promise = $executor->query($query);
 
         $promise->then($this->expectCallableOnceWith($message), $this->expectCallableNever());
     }
@@ -80,7 +80,7 @@ class CachingExecutorTest extends TestCase
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $promise = $executor->query('8.8.8.8', $query);
+        $promise = $executor->query($query);
 
         $promise->then($this->expectCallableOnceWith($message), $this->expectCallableNever());
     }
@@ -99,7 +99,7 @@ class CachingExecutorTest extends TestCase
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $promise = $executor->query('8.8.8.8', $query);
+        $promise = $executor->query($query);
 
         $promise->then($this->expectCallableOnceWith($message), $this->expectCallableNever());
     }
@@ -119,7 +119,7 @@ class CachingExecutorTest extends TestCase
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $promise = $executor->query('8.8.8.8', $query);
+        $promise = $executor->query($query);
 
         $promise->then($this->expectCallableOnceWith($message), $this->expectCallableNever());
     }
@@ -136,7 +136,7 @@ class CachingExecutorTest extends TestCase
 
         $executor = new CachingExecutor($fallback, $cache);
 
-        $promise = $executor->query('8.8.8.8', $query);
+        $promise = $executor->query($query);
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
     }
@@ -154,7 +154,7 @@ class CachingExecutorTest extends TestCase
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $promise = $executor->query('8.8.8.8', $query);
+        $promise = $executor->query($query);
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
@@ -174,7 +174,7 @@ class CachingExecutorTest extends TestCase
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $promise = $executor->query('8.8.8.8', $query);
+        $promise = $executor->query($query);
         $deferred->resolve(null);
         $promise->cancel();
 

--- a/tests/Query/CoopExecutorTest.php
+++ b/tests/Query/CoopExecutorTest.php
@@ -14,10 +14,10 @@ class CoopExecutorTest extends TestCase
         $pending = new Promise(function () { });
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
         $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $base->expects($this->once())->method('query')->with('8.8.8.8', $query)->willReturn($pending);
+        $base->expects($this->once())->method('query')->with($query)->willReturn($pending);
         $connector = new CoopExecutor($base);
 
-        $connector->query('8.8.8.8', $query);
+        $connector->query($query);
     }
 
     public function testQueryOnceWillResolveWhenBaseExecutorResolves()
@@ -29,7 +29,7 @@ class CoopExecutorTest extends TestCase
         $connector = new CoopExecutor($base);
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
-        $promise = $connector->query('8.8.8.8', $query);
+        $promise = $connector->query($query);
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
 
@@ -45,7 +45,7 @@ class CoopExecutorTest extends TestCase
         $connector = new CoopExecutor($base);
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
-        $promise = $connector->query('8.8.8.8', $query);
+        $promise = $connector->query($query);
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
 
@@ -59,13 +59,13 @@ class CoopExecutorTest extends TestCase
         $query2 = new Query('reactphp.org', Message::TYPE_AAAA, Message::CLASS_IN);
         $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
         $base->expects($this->exactly(2))->method('query')->withConsecutive(
-            array('8.8.8.8', $query1),
-            array('8.8.8.8', $query2)
+            array($query1),
+            array($query2)
         )->willReturn($pending);
         $connector = new CoopExecutor($base);
 
-        $connector->query('8.8.8.8', $query1);
-        $connector->query('8.8.8.8', $query2);
+        $connector->query($query1);
+        $connector->query($query2);
     }
 
     public function testQueryTwiceWillPassExactQueryToBaseExecutorOnceWhenQueryIsStillPending()
@@ -73,11 +73,11 @@ class CoopExecutorTest extends TestCase
         $pending = new Promise(function () { });
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
         $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $base->expects($this->once())->method('query')->with('8.8.8.8', $query)->willReturn($pending);
+        $base->expects($this->once())->method('query')->with($query)->willReturn($pending);
         $connector = new CoopExecutor($base);
 
-        $connector->query('8.8.8.8', $query);
-        $connector->query('8.8.8.8', $query);
+        $connector->query($query);
+        $connector->query($query);
     }
 
     public function testQueryTwiceWillPassExactQueryToBaseExecutorTwiceWhenFirstQueryIsAlreadyResolved()
@@ -86,15 +86,15 @@ class CoopExecutorTest extends TestCase
         $pending = new Promise(function () { });
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
         $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $base->expects($this->exactly(2))->method('query')->with('8.8.8.8', $query)->willReturnOnConsecutiveCalls($deferred->promise(), $pending);
+        $base->expects($this->exactly(2))->method('query')->with($query)->willReturnOnConsecutiveCalls($deferred->promise(), $pending);
 
         $connector = new CoopExecutor($base);
 
-        $connector->query('8.8.8.8', $query);
+        $connector->query($query);
 
         $deferred->resolve(new Message());
 
-        $connector->query('8.8.8.8', $query);
+        $connector->query($query);
     }
 
     public function testQueryTwiceWillPassExactQueryToBaseExecutorTwiceWhenFirstQueryIsAlreadyRejected()
@@ -103,15 +103,15 @@ class CoopExecutorTest extends TestCase
         $pending = new Promise(function () { });
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
         $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $base->expects($this->exactly(2))->method('query')->with('8.8.8.8', $query)->willReturnOnConsecutiveCalls($deferred->promise(), $pending);
+        $base->expects($this->exactly(2))->method('query')->with($query)->willReturnOnConsecutiveCalls($deferred->promise(), $pending);
 
         $connector = new CoopExecutor($base);
 
-        $connector->query('8.8.8.8', $query);
+        $connector->query($query);
 
         $deferred->reject(new RuntimeException());
 
-        $connector->query('8.8.8.8', $query);
+        $connector->query($query);
     }
 
     public function testCancelQueryWillCancelPromiseFromBaseExecutorAndReject()
@@ -123,7 +123,7 @@ class CoopExecutorTest extends TestCase
         $connector = new CoopExecutor($base);
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
-        $promise = $connector->query('8.8.8.8', $query);
+        $promise = $connector->query($query);
 
         $promise->cancel();
 
@@ -139,8 +139,8 @@ class CoopExecutorTest extends TestCase
         $connector = new CoopExecutor($base);
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
-        $promise1 = $connector->query('8.8.8.8', $query);
-        $promise2 = $connector->query('8.8.8.8', $query);
+        $promise1 = $connector->query($query);
+        $promise2 = $connector->query($query);
 
         $promise1->cancel();
 
@@ -157,8 +157,8 @@ class CoopExecutorTest extends TestCase
         $connector = new CoopExecutor($base);
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
-        $promise1 = $connector->query('8.8.8.8', $query);
-        $promise2 = $connector->query('8.8.8.8', $query);
+        $promise1 = $connector->query($query);
+        $promise2 = $connector->query($query);
 
         $promise2->cancel();
 
@@ -175,8 +175,8 @@ class CoopExecutorTest extends TestCase
         $connector = new CoopExecutor($base);
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
-        $promise1 = $connector->query('8.8.8.8', $query);
-        $promise2 = $connector->query('8.8.8.8', $query);
+        $promise1 = $connector->query($query);
+        $promise2 = $connector->query($query);
 
         $promise1->cancel();
         $promise2->cancel();
@@ -196,10 +196,10 @@ class CoopExecutorTest extends TestCase
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $promise1 = $connector->query('8.8.8.8', $query);
+        $promise1 = $connector->query($query);
         $promise1->cancel();
 
-        $promise2 = $connector->query('8.8.8.8', $query);
+        $promise2 = $connector->query($query);
 
         $promise1->then(null, $this->expectCallableOnce());
 
@@ -224,7 +224,7 @@ class CoopExecutorTest extends TestCase
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $promise = $connector->query('8.8.8.8', $query);
+        $promise = $connector->query($query);
         $promise->cancel();
         $promise = null;
 

--- a/tests/Query/HostsFileExecutorTest.php
+++ b/tests/Query/HostsFileExecutorTest.php
@@ -25,7 +25,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->never())->method('getIpsForHost');
         $this->fallback->expects($this->once())->method('query');
 
-        $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_MX, Message::CLASS_IN));
+        $this->executor->query(new Query('google.com', Message::TYPE_MX, Message::CLASS_IN));
     }
 
     public function testFallsBackIfNoIpsWereFound()
@@ -33,7 +33,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array());
         $this->fallback->expects($this->once())->method('query');
 
-        $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_A, Message::CLASS_IN));
+        $this->executor->query(new Query('google.com', Message::TYPE_A, Message::CLASS_IN));
     }
 
     public function testReturnsResponseMessageIfIpsWereFound()
@@ -41,7 +41,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('127.0.0.1'));
         $this->fallback->expects($this->never())->method('query');
 
-        $ret = $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_A, Message::CLASS_IN));
+        $ret = $this->executor->query(new Query('google.com', Message::TYPE_A, Message::CLASS_IN));
     }
 
     public function testFallsBackIfNoIpv4Matches()
@@ -49,7 +49,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('::1'));
         $this->fallback->expects($this->once())->method('query');
 
-        $ret = $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_A, Message::CLASS_IN));
+        $ret = $this->executor->query(new Query('google.com', Message::TYPE_A, Message::CLASS_IN));
     }
 
     public function testReturnsResponseMessageIfIpv6AddressesWereFound()
@@ -57,7 +57,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('::1'));
         $this->fallback->expects($this->never())->method('query');
 
-        $ret = $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_AAAA, Message::CLASS_IN));
+        $ret = $this->executor->query(new Query('google.com', Message::TYPE_AAAA, Message::CLASS_IN));
     }
 
     public function testFallsBackIfNoIpv6Matches()
@@ -65,7 +65,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('127.0.0.1'));
         $this->fallback->expects($this->once())->method('query');
 
-        $ret = $this->executor->query('8.8.8.8', new Query('google.com', Message::TYPE_AAAA, Message::CLASS_IN));
+        $ret = $this->executor->query(new Query('google.com', Message::TYPE_AAAA, Message::CLASS_IN));
     }
 
     public function testDoesReturnReverseIpv4Lookup()
@@ -73,7 +73,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->once())->method('getHostsForIp')->with('127.0.0.1')->willReturn(array('localhost'));
         $this->fallback->expects($this->never())->method('query');
 
-        $this->executor->query('8.8.8.8', new Query('1.0.0.127.in-addr.arpa', Message::TYPE_PTR, Message::CLASS_IN));
+        $this->executor->query(new Query('1.0.0.127.in-addr.arpa', Message::TYPE_PTR, Message::CLASS_IN));
     }
 
     public function testFallsBackIfNoReverseIpv4Matches()
@@ -81,7 +81,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->once())->method('getHostsForIp')->with('127.0.0.1')->willReturn(array());
         $this->fallback->expects($this->once())->method('query');
 
-        $this->executor->query('8.8.8.8', new Query('1.0.0.127.in-addr.arpa', Message::TYPE_PTR, Message::CLASS_IN));
+        $this->executor->query(new Query('1.0.0.127.in-addr.arpa', Message::TYPE_PTR, Message::CLASS_IN));
     }
 
     public function testDoesReturnReverseIpv6Lookup()
@@ -89,7 +89,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->once())->method('getHostsForIp')->with('2a02:2e0:3fe:100::6')->willReturn(array('ip6-localhost'));
         $this->fallback->expects($this->never())->method('query');
 
-        $this->executor->query('8.8.8.8', new Query('6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.e.f.3.0.0.e.2.0.2.0.a.2.ip6.arpa', Message::TYPE_PTR, Message::CLASS_IN));
+        $this->executor->query(new Query('6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.e.f.3.0.0.e.2.0.2.0.a.2.ip6.arpa', Message::TYPE_PTR, Message::CLASS_IN));
     }
 
     public function testFallsBackForInvalidAddress()
@@ -97,7 +97,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->never())->method('getHostsForIp');
         $this->fallback->expects($this->once())->method('query');
 
-        $this->executor->query('8.8.8.8', new Query('example.com', Message::TYPE_PTR, Message::CLASS_IN));
+        $this->executor->query(new Query('example.com', Message::TYPE_PTR, Message::CLASS_IN));
     }
 
     public function testReverseFallsBackForInvalidIpv4Address()
@@ -105,7 +105,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->never())->method('getHostsForIp');
         $this->fallback->expects($this->once())->method('query');
 
-        $this->executor->query('8.8.8.8', new Query('::1.in-addr.arpa', Message::TYPE_PTR, Message::CLASS_IN));
+        $this->executor->query(new Query('::1.in-addr.arpa', Message::TYPE_PTR, Message::CLASS_IN));
     }
 
     public function testReverseFallsBackForInvalidLengthIpv6Address()
@@ -113,7 +113,7 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->never())->method('getHostsForIp');
         $this->fallback->expects($this->once())->method('query');
 
-        $this->executor->query('8.8.8.8', new Query('abcd.ip6.arpa', Message::TYPE_PTR, Message::CLASS_IN));
+        $this->executor->query(new Query('abcd.ip6.arpa', Message::TYPE_PTR, Message::CLASS_IN));
     }
 
     public function testReverseFallsBackForInvalidHexIpv6Address()
@@ -121,6 +121,6 @@ class HostsFileExecutorTest extends TestCase
         $this->hosts->expects($this->never())->method('getHostsForIp');
         $this->fallback->expects($this->once())->method('query');
 
-        $this->executor->query('8.8.8.8', new Query('zZz.ip6.arpa', Message::TYPE_PTR, Message::CLASS_IN));
+        $this->executor->query(new Query('zZz.ip6.arpa', Message::TYPE_PTR, Message::CLASS_IN));
     }
 }

--- a/tests/Query/RetryExecutorTest.php
+++ b/tests/Query/RetryExecutorTest.php
@@ -24,13 +24,13 @@ class RetryExecutorTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with('8.8.8.8', $this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
             ->will($this->returnValue($this->expectPromiseOnce()));
 
         $retryExecutor = new RetryExecutor($executor, 2);
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $retryExecutor->query('8.8.8.8', $query);
+        $retryExecutor->query($query);
     }
 
     /**
@@ -45,12 +45,12 @@ class RetryExecutorTest extends TestCase
         $executor
             ->expects($this->exactly(2))
             ->method('query')
-            ->with('8.8.8.8', $this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
             ->will($this->onConsecutiveCalls(
-                $this->returnCallback(function ($domain, $query) {
+                $this->returnCallback(function ($query) {
                     return Promise\reject(new TimeoutException("timeout"));
                 }),
-                $this->returnCallback(function ($domain, $query) use ($response) {
+                $this->returnCallback(function ($query) use ($response) {
                     return Promise\resolve($response);
                 })
             ));
@@ -66,7 +66,7 @@ class RetryExecutorTest extends TestCase
         $retryExecutor = new RetryExecutor($executor, 2);
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $retryExecutor->query('8.8.8.8', $query)->then($callback, $errorback);
+        $retryExecutor->query($query)->then($callback, $errorback);
     }
 
     /**
@@ -79,8 +79,8 @@ class RetryExecutorTest extends TestCase
         $executor
             ->expects($this->exactly(3))
             ->method('query')
-            ->with('8.8.8.8', $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($domain, $query) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) {
                 return Promise\reject(new TimeoutException("timeout"));
             }));
 
@@ -95,7 +95,7 @@ class RetryExecutorTest extends TestCase
         $retryExecutor = new RetryExecutor($executor, 2);
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $retryExecutor->query('8.8.8.8', $query)->then($callback, $errorback);
+        $retryExecutor->query($query)->then($callback, $errorback);
     }
 
     /**
@@ -108,8 +108,8 @@ class RetryExecutorTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with('8.8.8.8', $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($domain, $query) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) {
                 return Promise\reject(new \Exception);
             }));
 
@@ -124,7 +124,7 @@ class RetryExecutorTest extends TestCase
         $retryExecutor = new RetryExecutor($executor, 2);
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $retryExecutor->query('8.8.8.8', $query)->then($callback, $errorback);
+        $retryExecutor->query($query)->then($callback, $errorback);
     }
 
     /**
@@ -139,8 +139,8 @@ class RetryExecutorTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with('8.8.8.8', $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($domain, $query) use (&$cancelled) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) use (&$cancelled) {
                 $deferred = new Deferred(function ($resolve, $reject) use (&$cancelled) {
                     ++$cancelled;
                     $reject(new CancellationException('Cancelled'));
@@ -153,7 +153,7 @@ class RetryExecutorTest extends TestCase
         $retryExecutor = new RetryExecutor($executor, 2);
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $promise = $retryExecutor->query('8.8.8.8', $query);
+        $promise = $retryExecutor->query($query);
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
 
@@ -175,10 +175,10 @@ class RetryExecutorTest extends TestCase
         $executor
             ->expects($this->exactly(2))
             ->method('query')
-            ->with('8.8.8.8', $this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
             ->will($this->onConsecutiveCalls(
                 $this->returnValue($deferred->promise()),
-                $this->returnCallback(function ($domain, $query) use (&$cancelled) {
+                $this->returnCallback(function ($query) use (&$cancelled) {
                     $deferred = new Deferred(function ($resolve, $reject) use (&$cancelled) {
                         ++$cancelled;
                         $reject(new CancellationException('Cancelled'));
@@ -191,7 +191,7 @@ class RetryExecutorTest extends TestCase
         $retryExecutor = new RetryExecutor($executor, 2);
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $promise = $retryExecutor->query('8.8.8.8', $query);
+        $promise = $retryExecutor->query($query);
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
 
@@ -217,14 +217,14 @@ class RetryExecutorTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with('8.8.8.8', $this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
             ->willReturn(Promise\resolve($this->createStandardResponse()));
 
         $retryExecutor = new RetryExecutor($executor, 0);
 
         gc_collect_cycles();
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $retryExecutor->query('8.8.8.8', $query);
+        $retryExecutor->query($query);
 
         $this->assertEquals(0, gc_collect_cycles());
     }
@@ -243,14 +243,14 @@ class RetryExecutorTest extends TestCase
         $executor
             ->expects($this->any())
             ->method('query')
-            ->with('8.8.8.8', $this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
             ->willReturn(Promise\reject(new TimeoutException("timeout")));
 
         $retryExecutor = new RetryExecutor($executor, 0);
 
         gc_collect_cycles();
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $retryExecutor->query('8.8.8.8', $query);
+        $retryExecutor->query($query);
 
         $this->assertEquals(0, gc_collect_cycles());
     }
@@ -273,14 +273,14 @@ class RetryExecutorTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with('8.8.8.8', $this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
             ->willReturn($deferred->promise());
 
         $retryExecutor = new RetryExecutor($executor, 0);
 
         gc_collect_cycles();
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $promise = $retryExecutor->query('8.8.8.8', $query);
+        $promise = $retryExecutor->query($query);
         $promise->cancel();
         $promise = null;
 
@@ -301,8 +301,8 @@ class RetryExecutorTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with('8.8.8.8', $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($domain, $query) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) {
                 return Promise\reject(new \Exception);
             }));
 
@@ -310,7 +310,7 @@ class RetryExecutorTest extends TestCase
 
         gc_collect_cycles();
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $retryExecutor->query('8.8.8.8', $query);
+        $retryExecutor->query($query);
 
         $this->assertEquals(0, gc_collect_cycles());
     }

--- a/tests/Query/TimeoutExecutorTest.php
+++ b/tests/Query/TimeoutExecutorTest.php
@@ -29,7 +29,7 @@ class TimeoutExecutorTest extends TestCase
         $this->wrapped
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnCallback(function ($domain, $query) use (&$cancelled) {
+            ->will($this->returnCallback(function ($query) use (&$cancelled) {
                 $deferred = new Deferred(function ($resolve, $reject) use (&$cancelled) {
                     ++$cancelled;
                     $reject(new CancellationException('Cancelled'));
@@ -39,7 +39,7 @@ class TimeoutExecutorTest extends TestCase
             }));
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $promise = $this->executor->query('8.8.8.8:53', $query);
+        $promise = $this->executor->query($query);
 
         $this->assertEquals(0, $cancelled);
         $promise->cancel();
@@ -56,7 +56,7 @@ class TimeoutExecutorTest extends TestCase
             ->willReturn(Promise\resolve('0.0.0.0'));
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $promise = $this->executor->query('8.8.8.8:53', $query);
+        $promise = $this->executor->query($query);
 
         $promise->then($this->expectCallableOnce(), $this->expectCallableNever());
     }
@@ -69,7 +69,7 @@ class TimeoutExecutorTest extends TestCase
             ->willReturn(Promise\reject(new \RuntimeException()));
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $promise = $this->executor->query('8.8.8.8:53', $query);
+        $promise = $this->executor->query($query);
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnceWith(new \RuntimeException()));
     }
@@ -83,7 +83,7 @@ class TimeoutExecutorTest extends TestCase
         $this->wrapped
             ->expects($this->once())
             ->method('query')
-            ->will($this->returnCallback(function ($domain, $query) use (&$cancelled) {
+            ->will($this->returnCallback(function ($query) use (&$cancelled) {
                 $deferred = new Deferred(function ($resolve, $reject) use (&$cancelled) {
                     ++$cancelled;
                     $reject(new CancellationException('Cancelled'));
@@ -104,7 +104,7 @@ class TimeoutExecutorTest extends TestCase
             ));
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $this->executor->query('8.8.8.8:53', $query)->then($callback, $errorback);
+        $this->executor->query($query)->then($callback, $errorback);
 
         $this->assertEquals(0, $cancelled);
 

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -19,16 +19,16 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
     }
 
-    /** @test */
-    public function createWithoutPortShouldCreateResolverWithDefaultPort()
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     */
+    public function createShouldThrowWhenNameserverIsInvalid()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
         $factory = new Factory();
-        $resolver = $factory->create('8.8.8.8', $loop);
-
-        $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
-        $this->assertSame('8.8.8.8:53', $this->getResolverPrivateMemberValue($resolver, 'nameserver'));
+        $factory->create('///', $loop);
     }
 
     /** @test */
@@ -60,33 +60,6 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('React\Dns\Query\CachingExecutor', $executor);
         $cacheProperty = $this->getCachingExecutorPrivateMemberValue($executor, 'cache');
         $this->assertSame($cache, $cacheProperty);
-    }
-
-    /**
-     * @test
-     * @dataProvider factoryShouldAddDefaultPortProvider
-     */
-    public function factoryShouldAddDefaultPort($input, $expected)
-    {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-
-        $factory = new Factory();
-        $resolver = $factory->create($input, $loop);
-
-        $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
-        $this->assertSame($expected, $this->getResolverPrivateMemberValue($resolver, 'nameserver'));
-    }
-
-    public static function factoryShouldAddDefaultPortProvider()
-    {
-        return array(
-            array('8.8.8.8',        '8.8.8.8:53'),
-            array('1.2.3.4:5',      '1.2.3.4:5'),
-            array('localhost',      'localhost:53'),
-            array('localhost:1234', 'localhost:1234'),
-            array('::1',            '[::1]:53'),
-            array('[::1]:53',       '[::1]:53')
-        );
     }
 
     private function getResolverPrivateExecutor($resolver)

--- a/tests/Resolver/ResolveAliasesTest.php
+++ b/tests/Resolver/ResolveAliasesTest.php
@@ -22,7 +22,7 @@ class ResolveAliasesTest extends TestCase
         $executor = $this->createExecutorMock();
         $executor->expects($this->once())->method('query')->willReturn(\React\Promise\resolve($message));
 
-        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver = new Resolver($executor);
 
         $answers = $resolver->resolveAll($name, Message::TYPE_A);
 

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -19,8 +19,8 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->anything(), $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($nameserver, $query) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
                 $response->questions[] = new Record($query->name, $query->type, $query->class);
@@ -29,7 +29,7 @@ class ResolverTest extends TestCase
                 return Promise\resolve($response);
             }));
 
-        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver = new Resolver($executor);
         $resolver->resolve('igor.io')->then($this->expectCallableOnceWith('178.79.169.131'));
     }
 
@@ -40,8 +40,8 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->anything(), $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($nameserver, $query) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
                 $response->questions[] = new Record($query->name, $query->type, $query->class);
@@ -50,7 +50,7 @@ class ResolverTest extends TestCase
                 return Promise\resolve($response);
             }));
 
-        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver = new Resolver($executor);
         $resolver->resolveAll('reactphp.org', Message::TYPE_AAAA)->then($this->expectCallableOnceWith(array('::1')));
     }
 
@@ -61,8 +61,8 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->anything(), $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($nameserver, $query) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
                 $response->questions[] = new Record($query->name, $query->type, $query->class);
@@ -72,7 +72,7 @@ class ResolverTest extends TestCase
                 return Promise\resolve($response);
             }));
 
-        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver = new Resolver($executor);
         $resolver->resolveAll('reactphp.org', Message::TYPE_AAAA)->then($this->expectCallableOnceWith(array('::1')));
     }
 
@@ -83,8 +83,8 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->anything(), $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($nameserver, $query) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
                 $response->questions[] = new Record($query->name, $query->type, $query->class);
@@ -95,7 +95,7 @@ class ResolverTest extends TestCase
                 return Promise\resolve($response);
             }));
 
-        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver = new Resolver($executor);
         $resolver->resolveAll('reactphp.org', Message::TYPE_AAAA)->then(
             $this->expectCallableOnceWith($this->equalTo(array('::1', '::2')))
         );
@@ -108,8 +108,8 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->anything(), $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($nameserver, $query) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
                 $response->questions[] = new Record('Blog.wyrihaximus.net', $query->type, $query->class);
@@ -118,7 +118,7 @@ class ResolverTest extends TestCase
                 return Promise\resolve($response);
             }));
 
-        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver = new Resolver($executor);
         $resolver->resolve('blog.wyrihaximus.net')->then($this->expectCallableOnceWith('178.79.169.131'));
     }
 
@@ -129,8 +129,8 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->anything(), $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($nameserver, $query) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
                 $response->questions[] = new Record($query->name, $query->type, $query->class);
@@ -141,7 +141,7 @@ class ResolverTest extends TestCase
 
         $errback = $this->expectCallableOnceWith($this->isInstanceOf('React\Dns\RecordNotFoundException'));
 
-        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver = new Resolver($executor);
         $resolver->resolve('igor.io')->then($this->expectCallableNever(), $errback);
     }
 
@@ -154,8 +154,8 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->anything(), $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($nameserver, $query) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
                 $response->questions[] = new Record($query->name, $query->type, $query->class);
@@ -167,7 +167,7 @@ class ResolverTest extends TestCase
             return ($param instanceof RecordNotFoundException && $param->getCode() === 0 && $param->getMessage() === 'DNS query for igor.io did not return a valid answer (NOERROR / NODATA)');
         }));
 
-        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver = new Resolver($executor);
         $resolver->resolve('igor.io')->then($this->expectCallableNever(), $errback);
     }
 
@@ -211,8 +211,8 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->anything(), $this->isInstanceOf('React\Dns\Query\Query'))
-            ->will($this->returnCallback(function ($nameserver, $query) use ($code) {
+            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->will($this->returnCallback(function ($query) use ($code) {
                 $response = new Message();
                 $response->qr = true;
                 $response->rcode = $code;
@@ -225,7 +225,7 @@ class ResolverTest extends TestCase
             return ($param instanceof RecordNotFoundException && $param->getCode() === $code && $param->getMessage() === $expectedMessage);
         }));
 
-        $resolver = new Resolver('8.8.8.8:53', $executor);
+        $resolver = new Resolver($executor);
         $resolver->resolve('example.com')->then($this->expectCallableNever(), $errback);
     }
 


### PR DESCRIPTION
This changeset adds documentation for the `ExecutorInterface` and marks its cancellation logic (#28) as required. Practically, this is only a documentation addition, but theoretically this could be considered a BC break for implementations of this interface that do not currently follow this API definition. These APIs are somewhat internal and it's very unlikely this will affect any consumers of this package.

The changeset builds on top of #135, see only the last commit for changes in this PR. I will rebase this once #135 is in.

Builds on top of #135 and #136
Refs #128