### PR TITLE
Remove unneeded dependency on react/stream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
         "react/cache": "^1.0 || ^0.6 || ^0.5",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
         "react/promise": "^2.1 || ^1.2.1",
-        "react/promise-timer": "^1.2",
-        "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.5"
+        "react/promise-timer": "^1.2"
     },
     "require-dev": {
         "clue/block-react": "^1.2",


### PR DESCRIPTION
This simple changeset removes the unneeded dependency on react/stream. This dependency became obsolete when we removed our legacy/deprecated APIs with #130. This does not affect usage otherwise.