### PR TITLE
Support parsing CAA records

### DIFF
--- a/examples/92-query-any.php
+++ b/examples/92-query-any.php
@@ -58,6 +58,11 @@ $executor->query($any)->then(function (Message $message) {
                 $type = 'SOA';
                 $data = json_encode($data);
                 break;
+            case Message::TYPE_CAA:
+                // CAA records contains flag, tag and value
+                $type = 'CAA';
+                $data = $data['flag'] . ' ' . $data['tag'] . ' "' . $data['value'] . '"';
+                break;
             default:
                 // unknown type uses HEX format
                 $type = 'Type ' . $answer->type;

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -21,6 +21,7 @@ final class Message
     const TYPE_AAAA = 28;
     const TYPE_SRV = 33;
     const TYPE_ANY = 255;
+    const TYPE_CAA = 257;
 
     const CLASS_IN = 1;
 

--- a/src/Model/Record.php
+++ b/src/Model/Record.php
@@ -84,6 +84,9 @@ final class Record
      *   minimum times in seconds (UINT32 each), for example:
      *   `{"mname":"ns.example.com","rname":"hostmaster.example.com","serial":
      *   2018082601,"refresh":3600,"retry":1800,"expire":60000,"minimum":3600}`.
+     * - CAA:
+     *   Includes flag (UNIT8), tag string and value string, for example:
+     *   `{"flag":128,"tag":"issue","value":"letsencrypt.org"}`
      * - Any other unknown type:
      *   An opaque binary string containing the RDATA as transported in the DNS
      *   record. For forwards compatibility, you should not rely on this format

--- a/src/Protocol/BinaryDumper.php
+++ b/src/Protocol/BinaryDumper.php
@@ -122,6 +122,15 @@ final class BinaryDumper
                         $record->data['minimum']
                     );
                     break;
+                case Message::TYPE_CAA:
+                    $binary = \pack(
+                        'C*',
+                        $record->data['flag'],
+                        \strlen($record->data['tag'])
+                    );
+                    $binary .= $record->data['tag'];
+                    $binary .= $record->data['value'];
+                    break;
                 default:
                     // RDATA is already stored as binary value for unknown record types
                     $binary = $record->data;

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -218,6 +218,22 @@ final class Parser
                     'minimum' => $minimum
                 );
             }
+        } elseif (Message::TYPE_CAA === $type) {
+            if ($rdLength > 3) {
+                list($flag, $tagLength) = array_values(unpack('C*', substr($message->data, $consumed, 2)));
+
+                if ($tagLength > 0 && $rdLength - 2 - $tagLength > 0) {
+                    $tag = substr($message->data, $consumed + 2, $tagLength);
+                    $value = substr($message->data, $consumed + 2 + $tagLength, $rdLength - 2 - $tagLength);
+                    $consumed += $rdLength;
+
+                    $rdata = array(
+                        'flag' => $flag,
+                        'tag' => $tag,
+                        'value' => $value
+                    );
+                }
+            }
         } else {
             // unknown types simply parse rdata as an opaque binary string
             $rdata = substr($message->data, $consumed, $rdLength);

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -57,6 +57,19 @@ class FunctionalTest extends TestCase
 
         $this->loop->run();
     }
+    /**
+     * @group internet
+     */
+    public function testResolveAllGoogleCaaResolvesWithCache()
+    {
+        $factory = new Factory();
+        $this->resolver = $factory->createCached('8.8.8.8', $this->loop);
+
+        $promise = $this->resolver->resolveAll('google.com', Message::TYPE_CAA);
+        $promise->then($this->expectCallableOnceWith($this->isType('array')), $this->expectCallableNever());
+
+        $this->loop->run();
+    }
 
     /**
      * @group internet

--- a/tests/Protocol/BinaryDumperTest.php
+++ b/tests/Protocol/BinaryDumperTest.php
@@ -180,21 +180,30 @@ class BinaryDumperTest extends TestCase
     public function testToBinaryForResponseWithMultipleAnswerRecords()
     {
         $data = "";
-        $data .= "72 62 01 00 00 01 00 04 00 00 00 00"; // header
+        $data .= "72 62 01 00 00 01 00 05 00 00 00 00"; // header
         $data .= "04 69 67 6f 72 02 69 6f 00";          // question: igor.io
         $data .= "00 ff 00 01";                         // question: type ANY, class IN
+
         $data .= "04 69 67 6f 72 02 69 6f 00";          // answer: igor.io
         $data .= "00 01 00 01 00 00 00 00 00 04";       // answer: type A, class IN, TTL 0, 4 bytes
         $data .= "7f 00 00 01";                         // answer: 127.0.0.1
+
         $data .= "04 69 67 6f 72 02 69 6f 00";          // answer: igor.io
         $data .= "00 1c 00 01 00 00 00 00 00 10";       // question: type AAAA, class IN, TTL 0, 16 bytes
         $data .= "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01"; // answer: ::1
+
         $data .= "04 69 67 6f 72 02 69 6f 00";          // answer: igor.io
         $data .= "00 10 00 01 00 00 00 00 00 0c";       // answer: type TXT, class IN, TTL 0, 12 bytes
         $data .= "05 68 65 6c 6c 6f 05 77 6f 72 6c 64"; // answer: hello, world
+
         $data .= "04 69 67 6f 72 02 69 6f 00";          // answer: igor.io
-        $data .= "00 0f 00 01 00 00 00 00 00 03";       // anwser: type MX, class IN, TTL 0, 3 bytes
-        $data .= "00 00 00";                            // priority 0, no target
+        $data .= "00 0f 00 01 00 00 00 00 00 03";       // answer: type MX, class IN, TTL 0, 3 bytes
+        $data .= "00 00 00";                            // answer: … priority 0, no target
+
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // answer: igor.io …
+        $data .= "01 01 00 01 00 00 00 00 00 16";       // answer: type CAA, class IN, TTL 0, 22 bytes
+        $data .= "00 05 69 73 73 75 65";                // answer: 0 issue …
+        $data .= "6c 65 74 73 65 6e 63 72 79 70 74 2e 6f 72 67"; // answer: … letsencrypt.org
 
         $expected = $this->formatHexDump($data);
 
@@ -213,6 +222,7 @@ class BinaryDumperTest extends TestCase
         $response->answers[] = new Record('igor.io', Message::TYPE_AAAA, Message::CLASS_IN, 0, '::1');
         $response->answers[] = new Record('igor.io', Message::TYPE_TXT, Message::CLASS_IN, 0, array('hello', 'world'));
         $response->answers[] = new Record('igor.io', Message::TYPE_MX, Message::CLASS_IN, 0, array('priority' => 0, 'target' => ''));
+        $response->answers[] = new Record('igor.io', Message::TYPE_CAA, Message::CLASS_IN, 0, array('flag' => 0, 'tag' => 'issue', 'value' => 'letsencrypt.org'));
 
         $dumper = new BinaryDumper();
         $data = $dumper->toBinary($response);


### PR DESCRIPTION
This changeset adds support for parsing and serializing CAA record types.

Refs #113 