### PR TITLE
Support parsing SSHFP records

### DIFF
--- a/examples/12-all-types.php
+++ b/examples/12-all-types.php
@@ -1,5 +1,8 @@
 <?php
 
+// $ php examples/12-all-types.php
+// $ php examples/12-all-types.php myserverplace.de SSHFP
+
 use React\Dns\Config\Config;
 use React\Dns\Resolver\Factory;
 

--- a/examples/92-query-any.php
+++ b/examples/92-query-any.php
@@ -49,9 +49,14 @@ $executor->query($any)->then(function (Message $message) {
                 $data = implode(' ', $data);
                 break;
             case Message::TYPE_SRV:
-                // SRV records contains priority, weight, port and target, dump structure here
+                // SRV records contain priority, weight, port and target, dump structure here
                 $type = 'SRV';
                 $data = json_encode($data);
+                break;
+            case Message::TYPE_SSHFP:
+                // SSHFP records contain algorithm, fingerprint type and hex fingerprint value
+                $type = 'SSHFP';
+                $data = implode(' ', $data);
                 break;
             case Message::TYPE_SOA:
                 // SOA records contain structured data, dump structure here

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -20,6 +20,7 @@ final class Message
     const TYPE_TXT = 16;
     const TYPE_AAAA = 28;
     const TYPE_SRV = 33;
+    const TYPE_SSHFP = 44;
     const TYPE_ANY = 255;
     const TYPE_CAA = 257;
 

--- a/src/Model/Record.php
+++ b/src/Model/Record.php
@@ -43,10 +43,13 @@ final class Record
      *
      * - A:
      *   IPv4 address string, for example "192.168.1.1".
+     *
      * - AAAA:
      *   IPv6 address string, for example "::1".
+     *
      * - CNAME / PTR / NS:
      *   The hostname without trailing dot, for example "reactphp.org".
+     *
      * - TXT:
      *   List of string values, for example `["v=spf1 include:example.com"]`.
      *   This is commonly a list with only a single string value, but this
@@ -58,6 +61,7 @@ final class Record
      *   suggests using key-value pairs such as `["name=test","version=1"]`, but
      *   interpretation of this is not enforced and left up to consumers of this
      *   library (used for DNS-SD/Zeroconf and others).
+     *
      * - MX:
      *   Mail server priority (UINT16) and target hostname without trailing dot,
      *   for example `{"priority":10,"target":"mx.example.com"}`.
@@ -66,6 +70,7 @@ final class Record
      *   referred to as exchange). If a response message contains multiple
      *   records of this type, targets should be sorted by priority (lowest
      *   first) - this is left up to consumers of this library (used for SMTP).
+     *
      * - SRV:
      *   Service priority (UINT16), service weight (UINT16), service port (UINT16)
      *   and target hostname without trailing dot, for example
@@ -78,15 +83,25 @@ final class Record
      *   randomly according to their weight - this is left up to consumers of
      *   this library, see also [RFC 2782](https://tools.ietf.org/html/rfc2782)
      *   for more details.
+     *
+     * - SSHFP:
+     *   Includes algorithm (UNIT8), fingerprint type (UNIT8) and fingerprint
+     *   value as lower case hex string, for example:
+     *   `{"algorithm":1,"type":1,"fingerprint":"0123456789abcdef..."}`
+     *   See also https://www.iana.org/assignments/dns-sshfp-rr-parameters/dns-sshfp-rr-parameters.xhtml
+     *   for algorithm and fingerprint type assignments.
+     *
      * - SOA:
      *   Includes master hostname without trailing dot, responsible person email
      *   as hostname without trailing dot and serial, refresh, retry, expire and
      *   minimum times in seconds (UINT32 each), for example:
      *   `{"mname":"ns.example.com","rname":"hostmaster.example.com","serial":
      *   2018082601,"refresh":3600,"retry":1800,"expire":60000,"minimum":3600}`.
+     *
      * - CAA:
      *   Includes flag (UNIT8), tag string and value string, for example:
      *   `{"flag":128,"tag":"issue","value":"letsencrypt.org"}`
+     *
      * - Any other unknown type:
      *   An opaque binary string containing the RDATA as transported in the DNS
      *   record. For forwards compatibility, you should not rely on this format

--- a/src/Protocol/BinaryDumper.php
+++ b/src/Protocol/BinaryDumper.php
@@ -131,6 +131,14 @@ final class BinaryDumper
                     $binary .= $record->data['tag'];
                     $binary .= $record->data['value'];
                     break;
+                case Message::TYPE_SSHFP:
+                    $binary = \pack(
+                        'CCH*',
+                        $record->data['algorithm'],
+                        $record->data['type'],
+                        $record->data['fingerprint']
+                    );
+                    break;
                 default:
                     // RDATA is already stored as binary value for unknown record types
                     $binary = $record->data;

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -200,6 +200,18 @@ final class Parser
                     'target' => $target
                 );
             }
+        } elseif (Message::TYPE_SSHFP === $type) {
+            if ($rdLength > 2) {
+                list($algorithm, $hash) = \array_values(\unpack('C*', \substr($message->data, $consumed, 2)));
+                $fingerprint = \bin2hex(\substr($message->data, $consumed + 2, $rdLength - 2));
+                $consumed += $rdLength;
+
+                $rdata = array(
+                    'algorithm' => $algorithm,
+                    'type' => $hash,
+                    'fingerprint' => $fingerprint
+                );
+            }
         } elseif (Message::TYPE_SOA === $type) {
             list($mname, $consumed) = $this->readDomain($message->data, $consumed);
             list($rname, $consumed) = $this->readDomain($message->data, $consumed);

--- a/tests/Protocol/BinaryDumperTest.php
+++ b/tests/Protocol/BinaryDumperTest.php
@@ -180,7 +180,7 @@ class BinaryDumperTest extends TestCase
     public function testToBinaryForResponseWithMultipleAnswerRecords()
     {
         $data = "";
-        $data .= "72 62 01 00 00 01 00 05 00 00 00 00"; // header
+        $data .= "72 62 01 00 00 01 00 06 00 00 00 00"; // header
         $data .= "04 69 67 6f 72 02 69 6f 00";          // question: igor.io
         $data .= "00 ff 00 01";                         // question: type ANY, class IN
 
@@ -205,6 +205,10 @@ class BinaryDumperTest extends TestCase
         $data .= "00 05 69 73 73 75 65";                // answer: 0 issue …
         $data .= "6c 65 74 73 65 6e 63 72 79 70 74 2e 6f 72 67"; // answer: … letsencrypt.org
 
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // answer: igor.io …
+        $data .= "00 2c 00 01 00 00 00 00 00 06";       // answer: type SSHFP, class IN, TTL 0, 6 bytes
+        $data .= "01 01 69 ac 09 0c";                   // answer: algorithm 1 (RSA), type 1 (SHA-1), fingerprint "69ac090c"
+
         $expected = $this->formatHexDump($data);
 
         $response = new Message();
@@ -223,6 +227,7 @@ class BinaryDumperTest extends TestCase
         $response->answers[] = new Record('igor.io', Message::TYPE_TXT, Message::CLASS_IN, 0, array('hello', 'world'));
         $response->answers[] = new Record('igor.io', Message::TYPE_MX, Message::CLASS_IN, 0, array('priority' => 0, 'target' => ''));
         $response->answers[] = new Record('igor.io', Message::TYPE_CAA, Message::CLASS_IN, 0, array('flag' => 0, 'tag' => 'issue', 'value' => 'letsencrypt.org'));
+        $response->answers[] = new Record('igor.io', Message::TYPE_SSHFP, Message::CLASS_IN, 0, array('algorithm' => 1, 'type' => '1', 'fingerprint' => '69ac090c'));
 
         $dumper = new BinaryDumper();
         $data = $dumper->toBinary($response);

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -517,6 +517,25 @@ class ParserTest extends TestCase
         $this->assertSame('hello', $response->answers[0]->data);
     }
 
+    public function testParseSSHFPResponse()
+    {
+        $data = "";
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // answer: igor.io
+        $data .= "00 2c 00 01";                         // answer: type SSHFP, class IN
+        $data .= "00 01 51 80";                         // answer: ttl 86400
+        $data .= "00 06";                               // answer: rdlength 6
+        $data .= "01 01 69 ac 09 0c";                   // answer: algorithm 1 (RSA), type 1 (SHA-1), fingerprint "69ac090c"
+
+        $response = $this->parseAnswer($data);
+
+        $this->assertCount(1, $response->answers);
+        $this->assertSame('igor.io', $response->answers[0]->name);
+        $this->assertSame(Message::TYPE_SSHFP, $response->answers[0]->type);
+        $this->assertSame(Message::CLASS_IN, $response->answers[0]->class);
+        $this->assertSame(86400, $response->answers[0]->ttl);
+        $this->assertSame(array('algorithm' => 1, 'type' => 1, 'fingerprint' => '69ac090c'), $response->answers[0]->data);
+    }
+
     public function testParseSOAResponse()
     {
         $data = "";
@@ -889,6 +908,21 @@ class ParserTest extends TestCase
         $data .= "00 01 51 80";                         // answer: ttl 86400
         $data .= "00 06";                               // answer: rdlength 6
         $data .= "00 0a 00 14 1F 90";                   // answer: rdata priority 10, weight 20, port 8080
+
+        $this->parseAnswer($data);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testParseInvalidSSHFPResponseWhereRecordIsTooSmall()
+    {
+        $data = "";
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // answer: igor.io
+        $data .= "00 2c 00 01";                         // answer: type SSHFP, class IN
+        $data .= "00 01 51 80";                         // answer: ttl 86400
+        $data .= "00 02";                               // answer: rdlength 2
+        $data .= "01 01";                               // answer: algorithm 1 (RSA), type 1 (SHA), missing fingerprint
 
         $this->parseAnswer($data);
     }


### PR DESCRIPTION
This changeset adds support for parsing and serializing SSHFP record types.

Builds on top of #141