### PR TITLE
Add missing private property definitions

### DIFF
--- a/src/Config/HostsFile.php
+++ b/src/Config/HostsFile.php
@@ -73,6 +73,8 @@ class HostsFile
         return new self($contents);
     }
 
+    private $contents;
+
     /**
      * Instantiate new hosts file with the given hosts file contents
      *

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -87,6 +87,7 @@ use React\Promise\Deferred;
  */
 final class UdpTransportExecutor implements ExecutorInterface
 {
+    private $nameserver;
     private $loop;
     private $parser;
     private $dumper;


### PR DESCRIPTION
Spotted via phpstan. Missing property definitions means that PHP
automatically allocates new properties as public properties.

Refs #75 and #135 