### PR TITLE
Support escaping literal dots and special characters in domain names

### DIFF
--- a/src/Protocol/BinaryDumper.php
+++ b/src/Protocol/BinaryDumper.php
@@ -175,6 +175,15 @@ final class BinaryDumper
             return "\0";
         }
 
-        return $this->textsToBinary(\explode('.', $host . '.'));
+        // break up domain name at each dot that is not preceeded by a backslash (escaped notation)
+        return $this->textsToBinary(
+            \array_map(
+                'stripcslashes',
+                \preg_split(
+                    '/(?<!\\\\)\./',
+                    $host . '.'
+                )
+            )
+        );
     }
 }

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -270,7 +270,19 @@ final class Parser
             return array(null, null);
         }
 
-        return array(implode('.', $labels), $consumed);
+        // use escaped notation for each label part, then join using dots
+        return array(
+            \implode(
+                '.',
+                \array_map(
+                    function ($label) {
+                        return \addcslashes($label, "\0..\40.\177");
+                    },
+                    $labels
+                )
+            ),
+            $consumed
+        );
     }
 
     private function readLabels($data, $consumed)


### PR DESCRIPTION
Among others, this is needed for PTR records for DNS-based service
discovery (DNS-SD) that contain "human friendly" names. The
backslash-escaping allows literal dots in the name (escaped) to be
distinguished from label-separator dots (not escaped).
See https://tools.ietf.org/html/rfc6763#section-4.3