### PR TITLE
Add TcpTransportExecutor to send DNS queries over TCP/IP connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ easily be used to create a DNS server.
   * [resolveAll()](#resolveall)
 * [Advanced usage](#advanced-usage)
   * [UdpTransportExecutor](#udptransportexecutor)
+  * [TcpTransportExecutor](#tcptransportexecutor)
   * [HostsFileExecutor](#hostsfileexecutor)
 * [Install](#install)
 * [Tests](#tests)
@@ -274,6 +275,71 @@ $executor = new CoopExecutor(
   of [react/datagram](https://github.com/reactphp/datagram) purely for
   organizational reasons to avoid a cyclic dependency between the two
   packages. Higher-level components should take advantage of the Datagram
+  component instead of reimplementing this socket logic from scratch.
+
+### TcpTransportExecutor
+
+The `TcpTransportExecutor` class can be used to
+send DNS queries over a TCP/IP stream transport.
+
+This is one of the main classes that send a DNS query to your DNS server.
+
+For more advanced usages one can utilize this class directly.
+The following example looks up the `IPv6` address for `reactphp.org`.
+
+```php
+$loop = Factory::create();
+$executor = new TcpTransportExecutor('8.8.8.8:53', $loop);
+
+$executor->query(
+    new Query($name, Message::TYPE_AAAA, Message::CLASS_IN)
+)->then(function (Message $message) {
+    foreach ($message->answers as $answer) {
+        echo 'IPv6: ' . $answer->data . PHP_EOL;
+    }
+}, 'printf');
+
+$loop->run();
+```
+
+See also [example #92](examples).
+
+Note that this executor does not implement a timeout, so you will very likely
+want to use this in combination with a `TimeoutExecutor` like this:
+
+```php
+$executor = new TimeoutExecutor(
+    new TcpTransportExecutor($nameserver, $loop),
+    3.0,
+    $loop
+);
+```
+
+Unlike the `UdpTransportExecutor`, this class uses a reliable TCP/IP
+transport, so you do not necessarily have to implement any retry logic.
+
+Note that this executor is entirely async and as such allows you to execute
+any number of queries concurrently. You should probably limit the number of
+concurrent queries in your application or you're very likely going to face
+rate limitations and bans on the resolver end. For many common applications,
+you may want to avoid sending the same query multiple times when the first
+one is still pending, so you will likely want to use this in combination with
+a `CoopExecutor` like this:
+
+```php
+$executor = new CoopExecutor(
+    new TimeoutExecutor(
+        new TcpTransportExecutor($nameserver, $loop),
+        3.0,
+        $loop
+    )
+);
+```
+
+> Internally, this class uses PHP's TCP/IP sockets and does not take advantage
+  of [react/socket](https://github.com/reactphp/socket) purely for
+  organizational reasons to avoid a cyclic dependency between the two
+  packages. Higher-level components should take advantage of the Socket
   component instead of reimplementing this socket logic from scratch.
 
 ### HostsFileExecutor

--- a/examples/92-query-any.php
+++ b/examples/92-query-any.php
@@ -1,15 +1,18 @@
 <?php
 
+// $ php examples/92-query-any.php mailbox.org
+// $ php examples/92-query-any.php _carddav._tcp.mailbox.org
+
 use React\Dns\Model\Message;
 use React\Dns\Model\Record;
 use React\Dns\Query\Query;
-use React\Dns\Query\UdpTransportExecutor;
+use React\Dns\Query\TcpTransportExecutor;
 use React\EventLoop\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$executor = new UdpTransportExecutor('8.8.8.8:53', $loop);
+$executor = new TcpTransportExecutor('8.8.8.8:53', $loop);
 
 $name = isset($argv[1]) ? $argv[1] : 'google.com';
 

--- a/src/Query/TcpTransportExecutor.php
+++ b/src/Query/TcpTransportExecutor.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace React\Dns\Query;
+
+use React\Dns\Model\Message;
+use React\Dns\Protocol\BinaryDumper;
+use React\Dns\Protocol\Parser;
+use React\EventLoop\LoopInterface;
+use React\Promise\Deferred;
+
+/**
+ * Send DNS queries over a TCP/IP stream transport.
+ *
+ * This is one of the main classes that send a DNS query to your DNS server.
+ *
+ * For more advanced usages one can utilize this class directly.
+ * The following example looks up the `IPv6` address for `reactphp.org`.
+ *
+ * ```php
+ * $loop = Factory::create();
+ * $executor = new TcpTransportExecutor('8.8.8.8:53', $loop);
+ *
+ * $executor->query(
+ *     new Query($name, Message::TYPE_AAAA, Message::CLASS_IN)
+ * )->then(function (Message $message) {
+ *     foreach ($message->answers as $answer) {
+ *         echo 'IPv6: ' . $answer->data . PHP_EOL;
+ *     }
+ * }, 'printf');
+ *
+ * $loop->run();
+ * ```
+ *
+ * See also [example #92](examples).
+ *
+ * Note that this executor does not implement a timeout, so you will very likely
+ * want to use this in combination with a `TimeoutExecutor` like this:
+ *
+ * ```php
+ * $executor = new TimeoutExecutor(
+ *     new TcpTransportExecutor($nameserver, $loop),
+ *     3.0,
+ *     $loop
+ * );
+ * ```
+ *
+ * Unlike the `UdpTransportExecutor`, this class uses a reliable TCP/IP
+ * transport, so you do not necessarily have to implement any retry logic.
+ *
+ * Note that this executor is entirely async and as such allows you to execute
+ * any number of queries concurrently. You should probably limit the number of
+ * concurrent queries in your application or you're very likely going to face
+ * rate limitations and bans on the resolver end. For many common applications,
+ * you may want to avoid sending the same query multiple times when the first
+ * one is still pending, so you will likely want to use this in combination with
+ * a `CoopExecutor` like this:
+ *
+ * ```php
+ * $executor = new CoopExecutor(
+ *     new TimeoutExecutor(
+ *         new TcpTransportExecutor($nameserver, $loop),
+ *         3.0,
+ *         $loop
+ *     )
+ * );
+ * ```
+ *
+ * > Internally, this class uses PHP's TCP/IP sockets and does not take advantage
+ *   of [react/socket](https://github.com/reactphp/socket) purely for
+ *   organizational reasons to avoid a cyclic dependency between the two
+ *   packages. Higher-level components should take advantage of the Socket
+ *   component instead of reimplementing this socket logic from scratch.
+ */
+class TcpTransportExecutor implements ExecutorInterface
+{
+    private $nameserver;
+    private $loop;
+    private $parser;
+    private $dumper;
+
+    /**
+     * @param string        $nameserver
+     * @param LoopInterface $loop
+     */
+    public function __construct($nameserver, LoopInterface $loop)
+    {
+        if (\strpos($nameserver, '[') === false && \substr_count($nameserver, ':') >= 2) {
+            // several colons, but not enclosed in square brackets => enclose IPv6 address in square brackets
+            $nameserver = '[' . $nameserver . ']';
+        }
+
+        $parts = \parse_url('tcp://' . $nameserver);
+        if (!isset($parts['scheme'], $parts['host']) || !\filter_var(\trim($parts['host'], '[]'), \FILTER_VALIDATE_IP)) {
+            throw new \InvalidArgumentException('Invalid nameserver address given');
+        }
+
+        $this->nameserver = $parts['host'] . ':' . (isset($parts['port']) ? $parts['port'] : 53);
+        $this->loop = $loop;
+        $this->parser = new Parser();
+        $this->dumper = new BinaryDumper();
+    }
+
+    public function query(Query $query)
+    {
+        $request = Message::createRequestForQuery($query);
+        $queryData = $this->dumper->toBinary($request);
+        $length = \strlen($queryData);
+        if ($length > 0xffff) {
+            return \React\Promise\reject(new \RuntimeException(
+                'DNS query for ' . $query->name . ' failed: Query too large for TCP transport'
+            ));
+        }
+
+        $queryData = \pack('n', $length) . $queryData;
+
+        // create async TCP/IP connection (may take a while)
+        $socket = @\stream_socket_client($this->nameserver, $errno, $errstr, 0, \STREAM_CLIENT_CONNECT | \STREAM_CLIENT_ASYNC_CONNECT);
+        if ($socket === false) {
+            return \React\Promise\reject(new \RuntimeException(
+                'DNS query for ' . $query->name . ' failed: Unable to connect to DNS server ('  . $errstr . ')',
+                $errno
+            ));
+        }
+
+        $loop = $this->loop;
+        $deferred = new Deferred(function () use ($loop, $socket, $query) {
+            // cancellation should remove socket from loop and close socket
+            $loop->removeReadStream($socket);
+            $loop->removeWriteStream($socket);
+            \fclose($socket);
+
+            throw new CancellationException('DNS query for ' . $query->name . ' has been cancelled');
+        });
+
+        // set socket to non-blocking and wait for it to become writable (connection success/rejected)
+        \stream_set_blocking($socket, false);
+        $loop->addWriteStream($socket, function ($socket) use ($loop, $query, $queryData, $deferred) {
+            $loop->removeWriteStream($socket);
+            $name = @\stream_socket_get_name($socket, true);
+            if ($name === false) {
+                $loop->removeReadStream($socket);
+                @\fclose($socket);
+                $deferred->reject(new \RuntimeException(
+                    'DNS query for ' . $query->name . ' failed: Connection to DNS server rejected'
+                ));
+                return;
+            }
+
+            $written = @\fwrite($socket, $queryData);
+            if ($written !== \strlen($queryData)) {
+                $loop->removeReadStream($socket);
+                \fclose($socket);
+                $deferred->reject(new \RuntimeException(
+                    'DNS query for ' . $query->name . ' failed: Unable to write DNS query message in one chunk'
+                ));
+            }
+        });
+
+        $buffer = '';
+        $parser = $this->parser;
+        $loop->addReadStream($socket, function ($socket) use (&$buffer, $loop, $deferred, $query, $parser, $request) {
+            // read one chunk of data from the DNS server
+            // any error is fatal, this is a stream of TCP/IP data
+            $chunk = @\fread($socket, 65536);
+            if ($chunk === false || $chunk === '') {
+                $loop->removeReadStream($socket);
+                \fclose($socket);
+                $deferred->reject(new \RuntimeException(
+                    'DNS query for ' . $query->name . ' failed: Connection to DNS server lost'
+                ));
+                return;
+            }
+
+            // reassemble complete message by concatenating all chunks.
+            // response message header contains at least 12 bytes
+            $buffer .= $chunk;
+            if (!isset($buffer[11])) {
+                return;
+            }
+
+            // read response message length from first 2 bytes and ensure we have length + data in buffer
+            list(, $length) = \unpack('n', $buffer);
+            if (!isset($buffer[$length + 1])) {
+                return;
+            }
+
+            // we only react to the first complete message, so remove socket from loop and close
+            $loop->removeReadStream($socket);
+            \fclose($socket);
+            $data = \substr($buffer, 2, $length);
+            $buffer = '';
+
+            try {
+                $response = $parser->parseMessage($data);
+            } catch (\Exception $e) {
+                // reject if we received an invalid message from remote server
+                $deferred->reject(new \RuntimeException(
+                    'DNS query for ' . $query->name . ' failed: Invalid message received from DNS server',
+                    0,
+                    $e
+                ));
+                return;
+            }
+
+            // reject if we received an unexpected response ID or truncated response
+            if ($response->id !== $request->id || $response->tc) {
+                $deferred->reject(new \RuntimeException(
+                    'DNS query for ' . $query->name . ' failed: Invalid response message received from DNS server'
+                ));
+                return;
+            }
+
+            $deferred->resolve($response);
+        });
+
+        return $deferred->promise();
+    }
+}

--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -1,0 +1,437 @@
+<?php
+
+namespace React\Tests\Dns\Query;
+
+use React\Dns\Model\Message;
+use React\Dns\Protocol\BinaryDumper;
+use React\Dns\Protocol\Parser;
+use React\Dns\Query\Query;
+use React\Dns\Query\TcpTransportExecutor;
+use React\EventLoop\Factory;
+use React\Tests\Dns\TestCase;
+
+class TcpTransportExecutorTest extends TestCase
+{
+    /**
+     * @dataProvider provideDefaultPortProvider
+     * @param string $input
+     * @param string $expected
+     */
+    public function testCtorShouldAcceptNameserverAddresses($input, $expected)
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $executor = new TcpTransportExecutor($input, $loop);
+
+        $ref = new \ReflectionProperty($executor, 'nameserver');
+        $ref->setAccessible(true);
+        $value = $ref->getValue($executor);
+
+        $this->assertEquals($expected, $value);
+    }
+
+    public static function provideDefaultPortProvider()
+    {
+        return array(
+            array('8.8.8.8',        '8.8.8.8:53'),
+            array('1.2.3.4:5',      '1.2.3.4:5'),
+            array('::1',            '[::1]:53'),
+            array('[::1]:53',       '[::1]:53')
+        );
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCtorShouldThrowWhenNameserverAddressIsInvalid()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        new TcpTransportExecutor('///', $loop);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCtorShouldThrowWhenNameserverAddressContainsHostname()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        new TcpTransportExecutor('localhost', $loop);
+    }
+
+    public function testQueryRejectsIfMessageExceedsMaximumMessageSize()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->never())->method('addReadStream');
+
+        $executor = new TcpTransportExecutor('8.8.8.8:53', $loop);
+
+        $query = new Query('google.' . str_repeat('.com', 60000), Message::TYPE_A, Message::CLASS_IN);
+        $promise = $executor->query($query);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testQueryRejectsIfServerConnectionFails()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->never())->method('addReadStream');
+
+        $executor = new TcpTransportExecutor('::1', $loop);
+
+        $ref = new \ReflectionProperty($executor, 'nameserver');
+        $ref->setAccessible(true);
+        $ref->setValue($executor, '///');
+
+        $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
+        $promise = $executor->query($query);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    /**
+     * @group internet
+     */
+    public function testQueryRejectsOnCancellation()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addWriteStream');
+        $loop->expects($this->once())->method('removeWriteStream');
+        $loop->expects($this->once())->method('addReadStream');
+        $loop->expects($this->once())->method('removeReadStream');
+
+        $executor = new TcpTransportExecutor('8.8.8.8:53', $loop);
+
+        $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
+        $promise = $executor->query($query);
+        $promise->cancel();
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testQueryRejectsWhenServerIsNotListening()
+    {
+        $loop = Factory::create();
+
+        $executor = new TcpTransportExecutor('127.0.0.1:1', $loop);
+
+        $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
+
+        $wait = true;
+        $executor->query($query)->then(
+            null,
+            function ($e) use (&$wait) {
+                $wait = false;
+                throw $e;
+            }
+        );
+
+        \Clue\React\Block\sleep(0.01, $loop);
+        if ($wait) {
+            \Clue\React\Block\sleep(0.2, $loop);
+        }
+
+        $this->assertFalse($wait);
+    }
+
+    public function testQueryRejectsWhenClientCanNotSendExcessiveMessageInOneChunk()
+    {
+        $writableCallback = null;
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addWriteStream')->with($this->anything(), $this->callback(function ($cb) use (&$writableCallback) {
+            $writableCallback = $cb;
+            return true;
+        }));
+        $loop->expects($this->once())->method('addReadStream');
+        $loop->expects($this->once())->method('removeWriteStream');
+        $loop->expects($this->once())->method('removeReadStream');
+
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+
+        $address = stream_socket_get_name($server, false);
+        $executor = new TcpTransportExecutor($address, $loop);
+
+        $query = new Query('google.' . str_repeat('.com', 1000), Message::TYPE_A, Message::CLASS_IN);
+
+        $promise = $executor->query($query);
+
+        // create new dummy socket and fill its outgoing write buffer
+        $socket = stream_socket_client($address);
+        stream_set_blocking($socket, false);
+        @fwrite($socket, str_repeat('.', 10000000));
+
+        // then manually invoke writable handler with dummy socket
+        $this->assertNotNull($writableCallback);
+        $writableCallback($socket);
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testQueryRejectsWhenServerClosesConnection()
+    {
+        $loop = Factory::create();
+
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+        $loop->addReadStream($server, function ($server) use ($loop) {
+            $client = stream_socket_accept($server);
+            fclose($client);
+        });
+
+        $address = stream_socket_get_name($server, false);
+        $executor = new TcpTransportExecutor($address, $loop);
+
+        $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
+
+        $wait = true;
+        $executor->query($query)->then(
+            null,
+            function ($e) use (&$wait) {
+                $wait = false;
+                throw $e;
+            }
+        );
+
+        \Clue\React\Block\sleep(0.01, $loop);
+        if ($wait) {
+            \Clue\React\Block\sleep(0.2, $loop);
+        }
+
+        $this->assertFalse($wait);
+    }
+
+    public function testQueryKeepsPendingIfServerSendsIncompleteMessageLength()
+    {
+        $loop = Factory::create();
+
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+        $loop->addReadStream($server, function ($server) use ($loop) {
+            $client = stream_socket_accept($server);
+            $loop->addReadStream($client, function ($client) use ($loop) {
+                $loop->removeReadStream($client);
+                fwrite($client, "\x00");
+            });
+
+            // keep reference to client to avoid disconnecting
+            $loop->addTimer(1, function () use ($client) { });
+        });
+
+        $address = stream_socket_get_name($server, false);
+        $executor = new TcpTransportExecutor($address, $loop);
+
+        $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
+
+        $wait = true;
+        $executor->query($query)->then(
+            null,
+            function ($e) use (&$wait) {
+                $wait = false;
+                throw $e;
+            }
+        );
+
+        \Clue\React\Block\sleep(0.2, $loop);
+        $this->assertTrue($wait);
+    }
+
+    public function testQueryKeepsPendingIfServerSendsIncompleteMessageBody()
+    {
+        $loop = Factory::create();
+
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+        $loop->addReadStream($server, function ($server) use ($loop) {
+            $client = stream_socket_accept($server);
+            $loop->addReadStream($client, function ($client) use ($loop) {
+                $loop->removeReadStream($client);
+                fwrite($client, "\x00\xff" . "some incomplete message data");
+            });
+
+            // keep reference to client to avoid disconnecting
+            $loop->addTimer(1, function () use ($client) { });
+        });
+
+        $address = stream_socket_get_name($server, false);
+        $executor = new TcpTransportExecutor($address, $loop);
+
+        $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
+
+        $wait = true;
+        $executor->query($query)->then(
+            null,
+            function ($e) use (&$wait) {
+                $wait = false;
+                throw $e;
+            }
+        );
+
+        \Clue\React\Block\sleep(0.2, $loop);
+        $this->assertTrue($wait);
+    }
+
+    public function testQueryRejectsWhenServerSendsInvalidMessage()
+    {
+        $loop = Factory::create();
+
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+        $loop->addReadStream($server, function ($server) use ($loop) {
+            $client = stream_socket_accept($server);
+            $loop->addReadStream($client, function ($client) use ($loop) {
+                $loop->removeReadStream($client);
+                fwrite($client, "\x00\x0f" . 'invalid message');
+            });
+        });
+
+        $address = stream_socket_get_name($server, false);
+        $executor = new TcpTransportExecutor($address, $loop);
+
+        $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
+
+        $wait = true;
+        $executor->query($query)->then(
+            null,
+            function ($e) use (&$wait) {
+                $wait = false;
+                throw $e;
+            }
+        );
+
+        \Clue\React\Block\sleep(0.01, $loop);
+        if ($wait) {
+            \Clue\React\Block\sleep(0.2, $loop);
+        }
+
+        $this->assertFalse($wait);
+    }
+
+    public function testQueryRejectsWhenServerSendsInvalidId()
+    {
+        $parser = new Parser();
+        $dumper = new BinaryDumper();
+
+        $loop = Factory::create();
+
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+        $loop->addReadStream($server, function ($server) use ($loop, $parser, $dumper) {
+            $client = stream_socket_accept($server);
+            $loop->addReadStream($client, function ($client) use ($loop, $parser, $dumper) {
+                $loop->removeReadStream($client);
+                $data = fread($client, 512);
+
+                list(, $length) = unpack('n', substr($data, 0, 2));
+                assert(strlen($data) - 2 === $length);
+                $data = substr($data, 2);
+
+                $message = $parser->parseMessage($data);
+                $message->id = 0;
+
+                $data = $dumper->toBinary($message);
+                $data = pack('n', strlen($data)) . $data;
+
+                fwrite($client, $data);
+            });
+        });
+
+        $address = stream_socket_get_name($server, false);
+        $executor = new TcpTransportExecutor($address, $loop);
+
+        $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
+
+        $wait = true;
+        $executor->query($query)->then(
+            null,
+            function ($e) use (&$wait) {
+                $wait = false;
+                throw $e;
+            }
+        );
+
+        \Clue\React\Block\sleep(0.01, $loop);
+        if ($wait) {
+            \Clue\React\Block\sleep(0.2, $loop);
+        }
+
+        $this->assertFalse($wait);
+    }
+
+    public function testQueryRejectsIfServerSendsTruncatedResponse()
+    {
+        $parser = new Parser();
+        $dumper = new BinaryDumper();
+
+        $loop = Factory::create();
+
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+        $loop->addReadStream($server, function ($server) use ($loop, $parser, $dumper) {
+            $client = stream_socket_accept($server);
+            $loop->addReadStream($client, function ($client) use ($loop, $parser, $dumper) {
+                $loop->removeReadStream($client);
+                $data = fread($client, 512);
+
+                list(, $length) = unpack('n', substr($data, 0, 2));
+                assert(strlen($data) - 2 === $length);
+                $data = substr($data, 2);
+
+                $message = $parser->parseMessage($data);
+                $message->tc = true;
+
+                $data = $dumper->toBinary($message);
+                $data = pack('n', strlen($data)) . $data;
+
+                fwrite($client, $data);
+            });
+        });
+
+        $address = stream_socket_get_name($server, false);
+        $executor = new TcpTransportExecutor($address, $loop);
+
+        $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
+
+        $wait = true;
+        $executor->query($query)->then(
+            null,
+            function ($e) use (&$wait) {
+                $wait = false;
+                throw $e;
+            }
+        );
+
+        \Clue\React\Block\sleep(0.01, $loop);
+        if ($wait) {
+            \Clue\React\Block\sleep(0.2, $loop);
+        }
+
+        $this->assertFalse($wait);
+    }
+
+    public function testQueryResolvesIfServerSendsValidResponse()
+    {
+        $loop = Factory::create();
+
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+        $loop->addReadStream($server, function ($server) use ($loop) {
+            $client = stream_socket_accept($server);
+            $loop->addReadStream($client, function ($client) use ($loop) {
+                $loop->removeReadStream($client);
+                $data = fread($client, 512);
+
+                list(, $length) = unpack('n', substr($data, 0, 2));
+                assert(strlen($data) - 2 === $length);
+
+                fwrite($client, $data);
+            });
+        });
+
+        $address = stream_socket_get_name($server, false);
+        $executor = new TcpTransportExecutor($address, $loop);
+
+        $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
+
+        $promise = $executor->query($query);
+        $response = \Clue\React\Block\await($promise, $loop, 0.2);
+
+        $this->assertInstanceOf('React\Dns\Model\Message', $response);
+    }
+}

--- a/tests/Query/UdpTransportExecutorTest.php
+++ b/tests/Query/UdpTransportExecutorTest.php
@@ -15,7 +15,7 @@ class UdpTransportExecutorTest extends TestCase
     /**
      * @dataProvider provideDefaultPortProvider
      * @param string $input
-     * @param strings $expected
+     * @param string $expected
      */
     public function testCtorShouldAcceptNameserverAddresses($input, $expected)
     {
@@ -124,7 +124,7 @@ class UdpTransportExecutorTest extends TestCase
         $this->assertTrue($wait);
     }
 
-    public function testQueryKeepsPendingIfServerSendInvalidMessage()
+    public function testQueryKeepsPendingIfServerSendsInvalidMessage()
     {
         $loop = Factory::create();
 
@@ -152,7 +152,7 @@ class UdpTransportExecutorTest extends TestCase
         $this->assertTrue($wait);
     }
 
-    public function testQueryKeepsPendingIfServerSendInvalidId()
+    public function testQueryKeepsPendingIfServerSendsInvalidId()
     {
         $parser = new Parser();
         $dumper = new BinaryDumper();


### PR DESCRIPTION
This changeset implements a fully functional TCP/IP transport for DNS
queries. In its current form, it requires manual setup (see examples)
and only the UDP transport is used by default. A follow-up PR will
implement proper transport selection based on query type and whether a
UDP query resulted in a truncated response.

Refs #19 