### PR TITLE
Optionally accept explicit udp:// and tcp:// scheme in Factory

### DIFF
--- a/src/Query/TcpTransportExecutor.php
+++ b/src/Query/TcpTransportExecutor.php
@@ -84,13 +84,13 @@ class TcpTransportExecutor implements ExecutorInterface
      */
     public function __construct($nameserver, LoopInterface $loop)
     {
-        if (\strpos($nameserver, '[') === false && \substr_count($nameserver, ':') >= 2) {
+        if (\strpos($nameserver, '[') === false && \substr_count($nameserver, ':') >= 2 && \strpos($nameserver, '://') === false) {
             // several colons, but not enclosed in square brackets => enclose IPv6 address in square brackets
             $nameserver = '[' . $nameserver . ']';
         }
 
-        $parts = \parse_url('tcp://' . $nameserver);
-        if (!isset($parts['scheme'], $parts['host']) || !\filter_var(\trim($parts['host'], '[]'), \FILTER_VALIDATE_IP)) {
+        $parts = \parse_url((\strpos($nameserver, '://') === false ? 'tcp://' : '') . $nameserver);
+        if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'tcp' || !\filter_var(\trim($parts['host'], '[]'), \FILTER_VALIDATE_IP)) {
             throw new \InvalidArgumentException('Invalid nameserver address given');
         }
 

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -98,13 +98,13 @@ final class UdpTransportExecutor implements ExecutorInterface
      */
     public function __construct($nameserver, LoopInterface $loop)
     {
-        if (strpos($nameserver, '[') === false && substr_count($nameserver, ':') >= 2) {
+        if (\strpos($nameserver, '[') === false && \substr_count($nameserver, ':') >= 2 && \strpos($nameserver, '://') === false) {
             // several colons, but not enclosed in square brackets => enclose IPv6 address in square brackets
             $nameserver = '[' . $nameserver . ']';
         }
 
-        $parts = parse_url('udp://' . $nameserver);
-        if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'udp') {
+        $parts = \parse_url((\strpos($nameserver, '://') === false ? 'udp://' : '') . $nameserver);
+        if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'udp' || !\filter_var(\trim($parts['host'], '[]'), \FILTER_VALIDATE_IP)) {
             throw new \InvalidArgumentException('Invalid nameserver address given');
         }
 

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -47,6 +47,34 @@ class FunctionalTest extends TestCase
     /**
      * @group internet
      */
+    public function testResolveGoogleOverUdpResolves()
+    {
+        $factory = new Factory($this->loop);
+        $this->resolver = $factory->create('udp://8.8.8.8', $this->loop);
+
+        $promise = $this->resolver->resolve('google.com');
+        $promise->then($this->expectCallableOnce(), $this->expectCallableNever());
+
+        $this->loop->run();
+    }
+
+    /**
+     * @group internet
+     */
+    public function testResolveGoogleOverTcpResolves()
+    {
+        $factory = new Factory($this->loop);
+        $this->resolver = $factory->create('tcp://8.8.8.8', $this->loop);
+
+        $promise = $this->resolver->resolve('google.com');
+        $promise->then($this->expectCallableOnce(), $this->expectCallableNever());
+
+        $this->loop->run();
+    }
+
+    /**
+     * @group internet
+     */
     public function testResolveAllGoogleMxResolvesWithCache()
     {
         $factory = new Factory();

--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -33,10 +33,30 @@ class TcpTransportExecutorTest extends TestCase
     public static function provideDefaultPortProvider()
     {
         return array(
-            array('8.8.8.8',        '8.8.8.8:53'),
-            array('1.2.3.4:5',      '1.2.3.4:5'),
-            array('::1',            '[::1]:53'),
-            array('[::1]:53',       '[::1]:53')
+            array(
+                '8.8.8.8',
+                '8.8.8.8:53'
+            ),
+            array(
+                '1.2.3.4:5',
+                '1.2.3.4:5'
+            ),
+            array(
+                'tcp://1.2.3.4',
+                '1.2.3.4:53'
+            ),
+            array(
+                'tcp://1.2.3.4:53',
+                '1.2.3.4:53'
+            ),
+            array(
+                '::1',
+                '[::1]:53'
+            ),
+            array(
+                '[::1]:53',
+                '[::1]:53'
+            )
         );
     }
 
@@ -58,6 +78,16 @@ class TcpTransportExecutorTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
         new TcpTransportExecutor('localhost', $loop);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCtorShouldThrowWhenNameserverSchemeIsInvalid()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        new TcpTransportExecutor('udp://1.2.3.4', $loop);
     }
 
     public function testQueryRejectsIfMessageExceedsMaximumMessageSize()

--- a/tests/Query/UdpTransportExecutorTest.php
+++ b/tests/Query/UdpTransportExecutorTest.php
@@ -33,12 +33,30 @@ class UdpTransportExecutorTest extends TestCase
     public static function provideDefaultPortProvider()
     {
         return array(
-            array('8.8.8.8',        'udp://8.8.8.8:53'),
-            array('1.2.3.4:5',      'udp://1.2.3.4:5'),
-            array('localhost',      'udp://localhost:53'),
-            array('localhost:1234', 'udp://localhost:1234'),
-            array('::1',            'udp://[::1]:53'),
-            array('[::1]:53',       'udp://[::1]:53')
+            array(
+                '8.8.8.8',
+                'udp://8.8.8.8:53'
+            ),
+            array(
+                '1.2.3.4:5',
+                'udp://1.2.3.4:5'
+            ),
+            array(
+                'udp://1.2.3.4',
+                'udp://1.2.3.4:53'
+            ),
+            array(
+                'udp://1.2.3.4:53',
+                'udp://1.2.3.4:53'
+            ),
+            array(
+                '::1',
+                'udp://[::1]:53'
+            ),
+            array(
+                '[::1]:53',
+                'udp://[::1]:53'
+            )
         );
     }
 
@@ -50,6 +68,26 @@ class UdpTransportExecutorTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
         new UdpTransportExecutor('///', $loop);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCtorShouldThrowWhenNameserverAddressContainsHostname()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        new UdpTransportExecutor('localhost', $loop);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCtorShouldThrowWhenNameserverSchemeIsInvalid()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        new UdpTransportExecutor('tcp://1.2.3.4', $loop);
     }
 
     public function testQueryRejectsIfMessageExceedsUdpSize()

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -19,6 +19,100 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
     }
 
+
+    /** @test */
+    public function createWithoutSchemeShouldCreateResolverWithUdpExecutorStack()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $factory = new Factory();
+        $resolver = $factory->create('8.8.8.8:53', $loop);
+
+        $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
+
+        $coopExecutor = $this->getResolverPrivateExecutor($resolver);
+
+        $this->assertInstanceOf('React\Dns\Query\CoopExecutor', $coopExecutor);
+
+        $ref = new \ReflectionProperty($coopExecutor, 'executor');
+        $ref->setAccessible(true);
+        $retryExecutor = $ref->getValue($coopExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
+
+        $ref = new \ReflectionProperty($retryExecutor, 'executor');
+        $ref->setAccessible(true);
+        $timeoutExecutor = $ref->getValue($retryExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
+
+        $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
+        $ref->setAccessible(true);
+        $udpExecutor = $ref->getValue($timeoutExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\UdpTransportExecutor', $udpExecutor);
+    }
+
+    /** @test */
+    public function createWithUdpSchemeShouldCreateResolverWithUdpExecutorStack()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $factory = new Factory();
+        $resolver = $factory->create('udp://8.8.8.8:53', $loop);
+
+        $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
+
+        $coopExecutor = $this->getResolverPrivateExecutor($resolver);
+
+        $this->assertInstanceOf('React\Dns\Query\CoopExecutor', $coopExecutor);
+
+        $ref = new \ReflectionProperty($coopExecutor, 'executor');
+        $ref->setAccessible(true);
+        $retryExecutor = $ref->getValue($coopExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
+
+        $ref = new \ReflectionProperty($retryExecutor, 'executor');
+        $ref->setAccessible(true);
+        $timeoutExecutor = $ref->getValue($retryExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
+
+        $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
+        $ref->setAccessible(true);
+        $udpExecutor = $ref->getValue($timeoutExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\UdpTransportExecutor', $udpExecutor);
+    }
+
+    /** @test */
+    public function createWithTcpSchemeShouldCreateResolverWithTcpExecutorStack()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $factory = new Factory();
+        $resolver = $factory->create('tcp://8.8.8.8:53', $loop);
+
+        $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
+
+        $coopExecutor = $this->getResolverPrivateExecutor($resolver);
+
+        $this->assertInstanceOf('React\Dns\Query\CoopExecutor', $coopExecutor);
+
+        $ref = new \ReflectionProperty($coopExecutor, 'executor');
+        $ref->setAccessible(true);
+        $timeoutExecutor = $ref->getValue($coopExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
+
+        $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
+        $ref->setAccessible(true);
+        $tcpExecutor = $ref->getValue($timeoutExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
+    }
+
     /**
      * @test
      * @expectedException InvalidArgumentException


### PR DESCRIPTION
The Factory defaults to creating a UDP-based executor-stack. One can now
explicitly specify the tcp:// URI scheme in order force using the new
TCP-based executor stack. In a follow-up changeset, the default will be
changed to automatic transport protocol detection (#19) and the explicit
choice will mostly exist for rare special cases and debugging purposes.

Builds on top of #145
Refs #19
Refs #5