### PR TITLE
Add SelectiveTransportExecutor to retry with TCP if UDP is truncated and automatically select transport protocol when no explicit scheme is given in Factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.3.0",
         "react/cache": "^1.0 || ^0.6 || ^0.5",
         "react/event-loop": "^1.0 || ^0.5",
-        "react/promise": "^2.1 || ^1.2.1",
+        "react/promise": "^2.7 || ^1.2.1",
         "react/promise-timer": "^1.2"
     },
     "require-dev": {

--- a/src/Query/SelectiveTransportExecutor.php
+++ b/src/Query/SelectiveTransportExecutor.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace React\Dns\Query;
+
+use React\Promise\Promise;
+
+/**
+ * Send DNS queries over a UDP or TCP/IP stream transport.
+ *
+ * This class will automatically choose the correct transport protocol to send
+ * a DNS query to your DNS server. It will always try to send it over the more
+ * efficient UDP transport first. If this query yields a size related issue
+ * (truncated messages), it will retry over a streaming TCP/IP transport.
+ *
+ * For more advanced usages one can utilize this class directly.
+ * The following example looks up the `IPv6` address for `reactphp.org`.
+ *
+ * ```php
+ * $executor = new SelectiveTransportExecutor($udpExecutor, $tcpExecutor);
+ *
+ * $executor->query(
+ *     new Query($name, Message::TYPE_AAAA, Message::CLASS_IN)
+ * )->then(function (Message $message) {
+ *     foreach ($message->answers as $answer) {
+ *         echo 'IPv6: ' . $answer->data . PHP_EOL;
+ *     }
+ * }, 'printf');
+ * ```
+ *
+ * Note that this executor only implements the logic to select the correct
+ * transport for the given DNS query. Implementing the correct transport logic,
+ * implementing timeouts and any retry logic is left up to the given executors,
+ * see also [`UdpTransportExecutor`](#udptransportexecutor) and
+ * [`TcpTransportExecutor`](#tcptransportexecutor) for more details.
+ *
+ * Note that this executor is entirely async and as such allows you to execute
+ * any number of queries concurrently. You should probably limit the number of
+ * concurrent queries in your application or you're very likely going to face
+ * rate limitations and bans on the resolver end. For many common applications,
+ * you may want to avoid sending the same query multiple times when the first
+ * one is still pending, so you will likely want to use this in combination with
+ * a `CoopExecutor` like this:
+ *
+ * ```php
+ * $executor = new CoopExecutor(
+ *     new SelectiveTransportExecutor(
+ *         $datagramExecutor,
+ *         $streamExecutor
+ *     )
+ * );
+ * ```
+ */
+class SelectiveTransportExecutor implements ExecutorInterface
+{
+    private $datagramExecutor;
+    private $streamExecutor;
+
+    public function __construct(ExecutorInterface $datagramExecutor, ExecutorInterface $streamExecutor)
+    {
+        $this->datagramExecutor = $datagramExecutor;
+        $this->streamExecutor = $streamExecutor;
+    }
+
+    public function query(Query $query)
+    {
+        $stream = $this->streamExecutor;
+        $pending = $this->datagramExecutor->query($query);
+
+        return new Promise(function ($resolve, $reject) use (&$pending, $stream, $query) {
+            $pending->then(
+                $resolve,
+                function ($e) use (&$pending, $stream, $query, $resolve, $reject) {
+                    if ($e->getCode() === (\defined('SOCKET_EMSGSIZE') ? \SOCKET_EMSGSIZE : 90)) {
+                        $pending = $stream->query($query)->then($resolve, $reject);
+                    } else {
+                        $reject($e);
+                    }
+                }
+            );
+        }, function () use (&$pending) {
+            $pending->cancel();
+            $pending = null;
+        });
+    }
+}

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -121,7 +121,8 @@ final class UdpTransportExecutor implements ExecutorInterface
         $queryData = $this->dumper->toBinary($request);
         if (isset($queryData[512])) {
             return \React\Promise\reject(new \RuntimeException(
-                'DNS query for ' . $query->name . ' failed: Query too large for UDP transport'
+                'DNS query for ' . $query->name . ' failed: Query too large for UDP transport',
+                \defined('SOCKET_EMSGSIZE') ? \SOCKET_EMSGSIZE : 90
             ));
         }
 
@@ -172,7 +173,10 @@ final class UdpTransportExecutor implements ExecutorInterface
             \fclose($socket);
 
             if ($response->tc) {
-                $deferred->reject(new \RuntimeException('DNS query for ' . $query->name . ' failed: The server returned a truncated result for a UDP query, but retrying via TCP is currently not supported'));
+                $deferred->reject(new \RuntimeException(
+                    'DNS query for ' . $query->name . ' failed: The server returned a truncated result for a UDP query',
+                    \defined('SOCKET_EMSGSIZE') ? \SOCKET_EMSGSIZE : 90
+                ));
                 return;
             }
 

--- a/tests/Query/SelectiveTransportExecutorTest.php
+++ b/tests/Query/SelectiveTransportExecutorTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace React\Tests\Dns\Query;
+
+use React\Dns\Model\Message;
+use React\Dns\Query\Query;
+use React\Dns\Query\SelectiveTransportExecutor;
+use React\Promise\Deferred;
+use React\Promise\Promise;
+use React\Tests\Dns\TestCase;
+
+class SelectiveTransportExecutorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->datagram = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $this->stream = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+
+        $this->executor = new SelectiveTransportExecutor($this->datagram, $this->stream);
+    }
+
+    public function testQueryResolvesWhenDatagramTransportResolvesWithoutUsingStreamTransport()
+    {
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
+
+        $response = new Message();
+
+        $this->datagram
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(\React\Promise\resolve($response));
+
+        $this->stream
+            ->expects($this->never())
+            ->method('query');
+
+        $promise = $this->executor->query($query);
+
+        $promise->then($this->expectCallableOnceWith($response));
+    }
+
+    public function testQueryResolvesWhenStreamTransportResolvesAfterDatagramTransportRejectsWithSizeError()
+    {
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
+
+        $response = new Message();
+
+        $this->datagram
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(\React\Promise\reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90)));
+
+        $this->stream
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(\React\Promise\resolve($response));
+
+        $promise = $this->executor->query($query);
+
+        $promise->then($this->expectCallableOnceWith($response));
+    }
+
+    public function testQueryRejectsWhenDatagramTransportRejectsWithRuntimeExceptionWithoutUsingStreamTransport()
+    {
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
+
+        $this->datagram
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(\React\Promise\reject(new \RuntimeException()));
+
+        $this->stream
+            ->expects($this->never())
+            ->method('query');
+
+        $promise = $this->executor->query($query);
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testQueryRejectsWhenStreamTransportRejectsAfterDatagramTransportRejectsWithSizeError()
+    {
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
+
+        $this->datagram
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(\React\Promise\reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90)));
+
+        $this->stream
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(\React\Promise\reject(new \RuntimeException()));
+
+        $promise = $this->executor->query($query);
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testCancelPromiseWillCancelPromiseFromDatagramExecutor()
+    {
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
+
+        $this->datagram
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(new Promise(function () {}, $this->expectCallableOnce()));
+
+        $promise = $this->executor->query($query);
+        $promise->cancel();
+    }
+
+    public function testCancelPromiseWillCancelPromiseFromStreamExecutorWhenDatagramExecutorRejectedWithTruncatedResponse()
+    {
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
+
+        $deferred = new Deferred();
+        $this->datagram
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn($deferred->promise());
+
+        $this->stream
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(new Promise(function () {}, $this->expectCallableOnce()));
+
+        $promise = $this->executor->query($query);
+        $deferred->reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90));
+        $promise->cancel();
+    }
+
+    public function testCancelPromiseShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
+
+        $this->datagram
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(new Promise(function () {}, function () {
+                throw new \RuntimeException('Cancelled');
+            }));
+
+        gc_collect_cycles();
+        $promise = $this->executor->query($query);
+        $promise->cancel();
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testCancelPromiseAfterTruncatedResponseShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
+
+        $deferred = new Deferred();
+        $this->datagram
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn($deferred->promise());
+
+        $this->stream
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(new Promise(function () {}, function () {
+                throw new \RuntimeException('Cancelled');
+            }));
+
+        gc_collect_cycles();
+        $promise = $this->executor->query($query);
+        $deferred->reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90));
+        $promise->cancel();
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testRejectedPromiseAfterTruncatedResponseShouldNotCreateAnyGarbageReferences()
+    {
+        $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
+
+        $this->datagram
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(\React\Promise\reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90)));
+
+        $this->stream
+            ->expects($this->once())
+            ->method('query')
+            ->with($query)
+            ->willReturn(\React\Promise\reject(new \RuntimeException()));
+
+        gc_collect_cycles();
+        $promise = $this->executor->query($query);
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+}

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -21,7 +21,7 @@ class FactoryTest extends TestCase
 
 
     /** @test */
-    public function createWithoutSchemeShouldCreateResolverWithUdpExecutorStack()
+    public function createWithoutSchemeShouldCreateResolverWithSelectiveUdpAndTcpExecutorStack()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -36,7 +36,15 @@ class FactoryTest extends TestCase
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
         $ref->setAccessible(true);
-        $retryExecutor = $ref->getValue($coopExecutor);
+        $selectiveExecutor = $ref->getValue($coopExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\SelectiveTransportExecutor', $selectiveExecutor);
+
+        // udp below:
+
+        $ref = new \ReflectionProperty($selectiveExecutor, 'datagramExecutor');
+        $ref->setAccessible(true);
+        $retryExecutor = $ref->getValue($selectiveExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
 
@@ -51,6 +59,20 @@ class FactoryTest extends TestCase
         $udpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\UdpTransportExecutor', $udpExecutor);
+
+        // tcp below:
+
+        $ref = new \ReflectionProperty($selectiveExecutor, 'streamExecutor');
+        $ref->setAccessible(true);
+        $timeoutExecutor = $ref->getValue($selectiveExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
+
+        $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
+        $ref->setAccessible(true);
+        $tcpExecutor = $ref->getValue($timeoutExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
     }
 
     /** @test */


### PR DESCRIPTION
With these changes applied, the Factory now defaults to automatically selecting the correct transport protocol in its executor-stack. It will always try to send it over the more efficient UDP transport first. If this query yields a size related issue (truncated messages), it will retry over a streaming TCP/IP transport.

It's still possible to explicitly specify the udp:// or tcp:// URI scheme in order force using only the UDP or TCP-based executor stacks respectively. This explicit choice continues to exist mostly for rare special cases and debugging purposes.

Builds on top of #145 and #146
Resolves #19 