### PR TITLE
Support parsing OPT records (EDNS0)

### DIFF
--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -51,6 +51,26 @@ final class Message
     const RCODE_REFUSED = 5;
 
     /**
+     * The edns-tcp-keepalive EDNS0 Option
+     *
+     * Option value contains a `?float` with timeout in seconds (in 0.1s steps)
+     * for DNS response or `null` for DNS query.
+     *
+     * @link https://tools.ietf.org/html/rfc7828
+     */
+    const OPT_TCP_KEEPALIVE = 11;
+
+    /**
+     * The EDNS(0) Padding Option
+     *
+     * Option value contains a `string` with binary data (usually variable
+     * number of null bytes)
+     *
+     * @link https://tools.ietf.org/html/rfc7830
+     */
+    const OPT_PADDING = 12;
+
+    /**
      * Creates a new request message for the given query
      *
      * @param Query $query

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -21,6 +21,19 @@ final class Message
     const TYPE_AAAA = 28;
     const TYPE_SRV = 33;
     const TYPE_SSHFP = 44;
+
+    /**
+     * pseudo-type for EDNS0
+     *
+     * These are included in the additional section and usually not in answer section.
+     * Defined in [RFC 6891](https://tools.ietf.org/html/rfc6891) (or older
+     * [RFC 2671](https://tools.ietf.org/html/rfc2671)).
+     *
+     * The OPT record uses the "class" field to store the maximum size.
+     *
+     * The OPT record uses the "ttl" field to store additional flags.
+     */
+    const TYPE_OPT = 41;
     const TYPE_ANY = 255;
     const TYPE_CAA = 257;
 

--- a/src/Model/Record.php
+++ b/src/Model/Record.php
@@ -24,13 +24,23 @@ final class Record
     public $type;
 
     /**
+     * Defines the network class, usually `Message::CLASS_IN`.
+     *
+     * For `OPT` records (EDNS0), this defines the maximum message size instead.
+     *
      * @var int see Message::CLASS_IN constant (UINT16)
+     * @see Message::CLASS_IN
      */
     public $class;
 
     /**
+     * Defines the maximum time-to-live (TTL) in seconds
+     *
+     * For `OPT` records (EDNS0), this defines additional flags instead.
+     *
      * @var int maximum TTL in seconds (UINT32, most significant bit always unset)
      * @link https://tools.ietf.org/html/rfc2181#section-8
+     * @link https://tools.ietf.org/html/rfc6891#section-6.1.3 for `OPT` records (EDNS0)
      */
     public $ttl;
 
@@ -101,6 +111,11 @@ final class Record
      * - CAA:
      *   Includes flag (UNIT8), tag string and value string, for example:
      *   `{"flag":128,"tag":"issue","value":"letsencrypt.org"}`
+     *
+     * - OPT:
+     *   Special pseudo-type for EDNS0. Includes an array of additional opt codes
+     *   with a binary string value in the form `[10=>"\x00",15=>"abc"]`. See
+     *   also [RFC 6891](https://tools.ietf.org/html/rfc6891) for more details.
      *
      * - Any other unknown type:
      *   An opaque binary string containing the RDATA as transported in the DNS

--- a/src/Model/Record.php
+++ b/src/Model/Record.php
@@ -114,8 +114,14 @@ final class Record
      *
      * - OPT:
      *   Special pseudo-type for EDNS0. Includes an array of additional opt codes
-     *   with a binary string value in the form `[10=>"\x00",15=>"abc"]`. See
-     *   also [RFC 6891](https://tools.ietf.org/html/rfc6891) for more details.
+     *   with a value according to the respective OPT code. See `Message::OPT_*`
+     *   for list of supported OPT codes. Any other OPT code not currently
+     *   supported will be an opaque binary string containing the raw data
+     *   as transported in the DNS record. For forwards compatibility, you should
+     *   not rely on this format for unknown types. Future versions may add
+     *   support for new types and this may then parse the payload data
+     *   appropriately - this will not be considered a BC break. See also
+     *   [RFC 6891](https://tools.ietf.org/html/rfc6891) for more details.
      *
      * - Any other unknown type:
      *   An opaque binary string containing the RDATA as transported in the DNS

--- a/src/Protocol/BinaryDumper.php
+++ b/src/Protocol/BinaryDumper.php
@@ -142,6 +142,9 @@ final class BinaryDumper
                 case Message::TYPE_OPT:
                     $binary = '';
                     foreach ($record->data as $opt => $value) {
+                        if ($opt === Message::OPT_TCP_KEEPALIVE && $value !== null) {
+                            $value = \pack('n', round($value * 10));
+                        }
                         $binary .= \pack('n*', $opt, \strlen($value)) . $value;
                     }
                     break;

--- a/src/Protocol/BinaryDumper.php
+++ b/src/Protocol/BinaryDumper.php
@@ -139,6 +139,12 @@ final class BinaryDumper
                         $record->data['fingerprint']
                     );
                     break;
+                case Message::TYPE_OPT:
+                    $binary = '';
+                    foreach ($record->data as $opt => $value) {
+                        $binary .= \pack('n*', $opt, \strlen($value)) . $value;
+                    }
+                    break;
                 default:
                     // RDATA is already stored as binary value for unknown record types
                     $binary = $record->data;

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -234,7 +234,16 @@ final class Parser
             $rdata = array();
             while (isset($message->data[$consumed + 4 - 1])) {
                 list($code, $length) = array_values(unpack('n*', substr($message->data, $consumed, 4)));
-                $rdata[$code] = (string) substr($message->data, $consumed + 4, $length);
+                $value = (string) substr($message->data, $consumed + 4, $length);
+                if ($code === Message::OPT_TCP_KEEPALIVE && $value === '') {
+                    $value = null;
+                } elseif ($code === Message::OPT_TCP_KEEPALIVE && $length === 2) {
+                    list($value) = array_values(unpack('n', $value));
+                    $value = round($value * 0.1, 1);
+                } elseif ($code === Message::OPT_TCP_KEEPALIVE) {
+                    break;
+                }
+                $rdata[$code] = $value;
                 $consumed += 4 + $length;
             }
         } elseif (Message::TYPE_CAA === $type) {

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -230,6 +230,13 @@ final class Parser
                     'minimum' => $minimum
                 );
             }
+        } elseif (Message::TYPE_OPT === $type) {
+            $rdata = array();
+            while (isset($message->data[$consumed + 4 - 1])) {
+                list($code, $length) = array_values(unpack('n*', substr($message->data, $consumed, 4)));
+                $rdata[$code] = (string) substr($message->data, $consumed + 4, $length);
+                $consumed += 4 + $length;
+            }
         } elseif (Message::TYPE_CAA === $type) {
             if ($rdLength > 3) {
                 list($flag, $tagLength) = array_values(unpack('C*', substr($message->data, $consumed, 2)));

--- a/tests/Protocol/BinaryDumperTest.php
+++ b/tests/Protocol/BinaryDumperTest.php
@@ -96,6 +96,105 @@ class BinaryDumperTest extends TestCase
         $this->assertSame($expected, $data);
     }
 
+    public function testToBinaryRequestMessageWithAdditionalOptForEdns0WithOptTcpKeepAliveDesired()
+    {
+        $data = "";
+        $data .= "72 62 01 00 00 01 00 00 00 00 00 01"; // header
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // question: igor.io
+        $data .= "00 01 00 01";                         // question: type A, class IN
+        $data .= "00";                                  // additional: (empty hostname)
+        $data .= "00 29 03 e8 00 00 00 00 00 04 ";      // additional: type OPT, class 1000 UDP size, TTL 0, 4 bytes RDATA
+        $data .= "00 0b 00 00";                         // OPT_TCP_KEEPALIVE=null encoded
+
+        $expected = $this->formatHexDump($data);
+
+        $request = new Message();
+        $request->id = 0x7262;
+        $request->rd = true;
+
+        $request->questions[] = new Query(
+            'igor.io',
+            Message::TYPE_A,
+            Message::CLASS_IN
+        );
+
+        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, array(
+            Message::OPT_TCP_KEEPALIVE => null,
+        ));
+
+        $dumper = new BinaryDumper();
+        $data = $dumper->toBinary($request);
+        $data = $this->convertBinaryToHexDump($data);
+
+        $this->assertSame($expected, $data);
+    }
+
+    public function testToBinaryRequestMessageWithAdditionalOptForEdns0WithOptTcpKeepAliveGiven()
+    {
+        $data = "";
+        $data .= "72 62 01 00 00 01 00 00 00 00 00 01"; // header
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // question: igor.io
+        $data .= "00 01 00 01";                         // question: type A, class IN
+        $data .= "00";                                  // additional: (empty hostname)
+        $data .= "00 29 03 e8 00 00 00 00 00 06 ";      // additional: type OPT, class 1000 UDP size, TTL 0, 6 bytes RDATA
+        $data .= "00 0b 00 02 00 0c";                   // OPT_TCP_KEEPALIVE=1.2 encoded
+
+        $expected = $this->formatHexDump($data);
+
+        $request = new Message();
+        $request->id = 0x7262;
+        $request->rd = true;
+
+        $request->questions[] = new Query(
+            'igor.io',
+            Message::TYPE_A,
+            Message::CLASS_IN
+        );
+
+        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, array(
+            Message::OPT_TCP_KEEPALIVE => 1.2,
+        ));
+
+        $dumper = new BinaryDumper();
+        $data = $dumper->toBinary($request);
+        $data = $this->convertBinaryToHexDump($data);
+
+        $this->assertSame($expected, $data);
+    }
+
+    public function testToBinaryRequestMessageWithAdditionalOptForEdns0WithOptPadding()
+    {
+        $data = "";
+        $data .= "72 62 01 00 00 01 00 00 00 00 00 01"; // header
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // question: igor.io
+        $data .= "00 01 00 01";                         // question: type A, class IN
+        $data .= "00";                                  // additional: (empty hostname)
+        $data .= "00 29 03 e8 00 00 00 00 00 06 ";      // additional: type OPT, class 1000 UDP size, TTL 0, 6 bytes RDATA
+        $data .= "00 0c 00 02 00 00 ";                  // OPT_PADDING=0x0000 encoded
+
+        $expected = $this->formatHexDump($data);
+
+        $request = new Message();
+        $request->id = 0x7262;
+        $request->rd = true;
+
+        $request->questions[] = new Query(
+            'igor.io',
+            Message::TYPE_A,
+            Message::CLASS_IN
+        );
+
+        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, array(
+            Message::OPT_PADDING => "\x00\x00"
+        ));
+
+        $dumper = new BinaryDumper();
+        $data = $dumper->toBinary($request);
+        $data = $this->convertBinaryToHexDump($data);
+
+        $this->assertSame($expected, $data);
+    }
+
     public function testToBinaryRequestMessageWithAdditionalOptForEdns0WithCustomOptCodes()
     {
         $data = "";
@@ -121,7 +220,7 @@ class BinaryDumperTest extends TestCase
 
         $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, array(
             0xa0 => 'foo',
-            0x01 => "\x00\00"
+            0x01 => "\x00\x00"
         ));
 
         $dumper = new BinaryDumper();

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -554,6 +554,44 @@ class ParserTest extends TestCase
         $this->assertSame(array(), $response->answers[0]->data);
     }
 
+    public function testParseOptResponseWithOptTcpKeepaliveDesired()
+    {
+        $data = "";
+        $data .= "00";                                  // answer: empty domain
+        $data .= "00 29 03 e8";                         // answer: type OPT, class 1000 UDP size
+        $data .= "00 00 00 00";                         // answer: ttl 0
+        $data .= "00 04";                               // answer: rdlength 4
+        $data .= "00 0b 00 00";                         // OPT_TCP_KEEPALIVE=null encoded
+
+        $response = $this->parseAnswer($data);
+
+        $this->assertCount(1, $response->answers);
+        $this->assertSame('', $response->answers[0]->name);
+        $this->assertSame(Message::TYPE_OPT, $response->answers[0]->type);
+        $this->assertSame(1000, $response->answers[0]->class);
+        $this->assertSame(0, $response->answers[0]->ttl);
+        $this->assertSame(array(Message::OPT_TCP_KEEPALIVE => null), $response->answers[0]->data);
+    }
+
+    public function testParseOptResponseWithOptTcpKeepaliveGiven()
+    {
+        $data = "";
+        $data .= "00";                                  // answer: empty domain
+        $data .= "00 29 03 e8";                         // answer: type OPT, class 1000 UDP size
+        $data .= "00 00 00 00";                         // answer: ttl 0
+        $data .= "00 06";                               // answer: rdlength 4
+        $data .= "00 0b 00 02 00 0c";                   // OPT_TCP_KEEPALIVE=1.2s encoded
+
+        $response = $this->parseAnswer($data);
+
+        $this->assertCount(1, $response->answers);
+        $this->assertSame('', $response->answers[0]->name);
+        $this->assertSame(Message::TYPE_OPT, $response->answers[0]->type);
+        $this->assertSame(1000, $response->answers[0]->class);
+        $this->assertSame(0, $response->answers[0]->ttl);
+        $this->assertSame(array(Message::OPT_TCP_KEEPALIVE => 1.2), $response->answers[0]->data);
+    }
+
     public function testParseOptResponseWithCustomOptions()
     {
         $data = "";
@@ -1006,6 +1044,21 @@ class ParserTest extends TestCase
         $data .= "00 00 00 00";                         // answer: ttl 0
         $data .= "00 03";                               // answer: rdlength 3
         $data .= "00 00 00";                            // answer: type 0, length incomplete
+
+        $this->parseAnswer($data);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testParseInvalidOPTResponseWhereRecordLengthDoesNotMatchOptType()
+    {
+        $data = "";
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // answer: igor.io
+        $data .= "00 29 03 e8";                         // answer: type OPT, 1000 bytes max size
+        $data .= "00 00 00 00";                         // answer: ttl 0
+        $data .= "00 07";                               // answer: rdlength 7
+        $data .= "00 0b 00 03 01 02 03";                // answer: type OPT_TCP_KEEPALIVE, length 3 instead of 2
 
         $this->parseAnswer($data);
     }


### PR DESCRIPTION
This PR adds support for parsing and serializing `OPT` record types in accordance to [RFC 6891](https://tools.ietf.org/html/rfc6891). Among others, this is a prerequisite for parsing EDNS0 responses (#100) and also DNSSEC, DNS-over-TLS (DoT #80) and DNS-over-HTTPS (DoH) which is left up to a follow-up PR. This is a pure feature addition (without any BC breaks), though this is not currently used in practice.

Builds on top of #123 and #124
Refs #100 