### PR TITLE
Resolver: support other query classes

### DIFF
--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -37,7 +37,9 @@ final class Message
     const TYPE_ANY = 255;
     const TYPE_CAA = 257;
 
-    const CLASS_IN = 1;
+    const CLASS_IN = 1; // Internet
+    const CLASS_CH = 3; // Chaos
+    const CLASS_HS = 4; // Hesiod
 
     const OPCODE_QUERY = 0;
     const OPCODE_IQUERY = 1; // inverse query

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -19,16 +19,16 @@ final class Resolver implements ResolverInterface
         $this->executor = $executor;
     }
 
-    public function resolve($domain)
+    public function resolve($domain, $type = Message::TYPE_A, $class = Message::CLASS_IN)
     {
-        return $this->resolveAll($domain, Message::TYPE_A)->then(function (array $ips) {
+        return $this->resolveAll($domain, $type, $class)->then(function (array $ips) {
             return $ips[array_rand($ips)];
         });
     }
 
-    public function resolveAll($domain, $type)
+    public function resolveAll($domain, $type = Message::TYPE_A, $class = Message::CLASS_IN)
     {
-        $query = new Query($domain, $type, Message::CLASS_IN);
+        $query = new Query($domain, $type, $class);
         $that = $this;
 
         return $this->executor->query(

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -102,6 +102,20 @@ class FunctionalTest extends TestCase
     /**
      * @group internet
      */
+    public function testResolveKRootServerId()
+    {
+        $factory = new Factory($this->loop);
+        $this->resolver = $factory->create('udp://193.0.14.129', $this->loop);
+
+        $promise = $this->resolver->resolve('id.server', Message::TYPE_TXT, Message::CLASS_CH);
+        $promise->then($this->expectCallableOnce(), $this->expectCallableNever());
+
+        $this->loop->run();
+    }
+
+    /**
+     * @group internet
+     */
     public function testResolveInvalidRejects()
     {
         $ex = $this->callback(function ($param) {


### PR DESCRIPTION
This introduces constants for CH (Chaos) and HS (Hesiod) classes and
allows to optionally pass type and class to both resolve and resolveAll