### PR TITLE
Implement SPF dns record type

### DIFF
--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -34,6 +34,7 @@ final class Message
      * The OPT record uses the "ttl" field to store additional flags.
      */
     const TYPE_OPT = 41;
+    const TYPE_SPF = 99; // Sender Policy Framework (SPF) - https://tools.ietf.org/html/rfc4408#section-3.1.1
     const TYPE_ANY = 255;
     const TYPE_CAA = 257;
 

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -171,7 +171,7 @@ final class Parser
             }
         } elseif (Message::TYPE_CNAME === $type || Message::TYPE_PTR === $type || Message::TYPE_NS === $type) {
             list($rdata, $consumed) = $this->readDomain($message->data, $consumed);
-        } elseif (Message::TYPE_TXT === $type) {
+        } elseif (Message::TYPE_TXT === $type || Message::TYPE_SPF === $type) {
             $rdata = array();
             while ($consumed < $expected) {
                 $len = ord($message->data[$consumed]);

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -302,6 +302,25 @@ class ParserTest extends TestCase
         $this->assertSame(array('hello'), $response->answers[0]->data);
     }
 
+    public function testParseSPFResponse()
+    {
+        $data = "";
+        $data .= "04 69 67 6f 72 02 69 6f 00";          // answer: igor.io
+        $data .= "00 63 00 01";                         // answer: type SPF, class IN
+        $data .= "00 01 51 80";                         // answer: ttl 86400
+        $data .= "00 06";                               // answer: rdlength 6
+        $data .= "05 68 65 6c 6c 6f";                   // answer: rdata length 5: hello
+
+        $response = $this->parseAnswer($data);
+
+        $this->assertCount(1, $response->answers);
+        $this->assertSame('igor.io', $response->answers[0]->name);
+        $this->assertSame(Message::TYPE_SPF, $response->answers[0]->type);
+        $this->assertSame(Message::CLASS_IN, $response->answers[0]->class);
+        $this->assertSame(86400, $response->answers[0]->ttl);
+        $this->assertSame(array('hello'), $response->answers[0]->data);
+    }
+
     public function testParseTXTResponseMultiple()
     {
         $data = "";


### PR DESCRIPTION
Despite the fact that this record is already deprecated, we need to check if it exists at all (for example when validating user spf record).

RFC: https://tools.ietf.org/html/rfc4408#section-3.1.1