### PR TITLE
Fix failing test on PHP 7.4 with code coverage when skipping some tests

### DIFF
--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -188,6 +188,7 @@ class FunctionalTest extends TestCase
         $this->resolver = $factory->create('127.0.0.1', $this->loop);
 
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
 
         $promise = $this->resolver->resolve('google.com');
         $promise->cancel();

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -7,7 +7,7 @@ use React\Dns\Resolver\Factory;
 use React\Dns\RecordNotFoundException;
 use React\Dns\Model\Message;
 
-class FunctionalTest extends TestCase
+class FunctionalResolverTest extends TestCase
 {
     /**
      * @before
@@ -171,6 +171,7 @@ class FunctionalTest extends TestCase
         $this->resolver = $factory->createCached('255.255.255.255', $this->loop);
 
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
 
         $promise = $this->resolver->resolve('google.com');
         unset($promise);
@@ -207,6 +208,7 @@ class FunctionalTest extends TestCase
         $this->resolver = $factory->createCached('127.0.0.1', $this->loop);
 
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
 
         $promise = $this->resolver->resolve('google.com');
         $promise->cancel();

--- a/tests/Query/CoopExecutorTest.php
+++ b/tests/Query/CoopExecutorTest.php
@@ -221,6 +221,7 @@ class CoopExecutorTest extends TestCase
         $connector = new CoopExecutor($base);
 
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 

--- a/tests/Query/RetryExecutorTest.php
+++ b/tests/Query/RetryExecutorTest.php
@@ -251,6 +251,8 @@ class RetryExecutorTest extends TestCase
         $retryExecutor = new RetryExecutor($executor, 0);
 
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
+
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
         $retryExecutor->query($query);
 
@@ -281,6 +283,8 @@ class RetryExecutorTest extends TestCase
         $retryExecutor = new RetryExecutor($executor, 0);
 
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
+
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
         $promise = $retryExecutor->query($query);
         $promise->cancel();
@@ -311,6 +315,8 @@ class RetryExecutorTest extends TestCase
         $retryExecutor = new RetryExecutor($executor, 2);
 
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
+
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
         $retryExecutor->query($query);
 

--- a/tests/Query/SelectiveTransportExecutorTest.php
+++ b/tests/Query/SelectiveTransportExecutorTest.php
@@ -159,6 +159,8 @@ class SelectiveTransportExecutorTest extends TestCase
             }));
 
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
+
         $promise = $this->executor->query($query);
         $promise->cancel();
         unset($promise);
@@ -190,6 +192,8 @@ class SelectiveTransportExecutorTest extends TestCase
             }));
 
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
+
         $promise = $this->executor->query($query);
         $deferred->reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90));
         $promise->cancel();
@@ -215,6 +219,8 @@ class SelectiveTransportExecutorTest extends TestCase
             ->willReturn(\React\Promise\reject(new \RuntimeException()));
 
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
+
         $promise = $this->executor->query($query);
         unset($promise);
 


### PR DESCRIPTION
This only reports an error on PHP 7.4 when executed like this:

```
$ vendor/bin/phpunit --coverage-text --exclude-group internet
```

This has been worked around by clearing garbage twice (see #156). Interestingly, this does not actually affect any of the excluded tests but only seems to show up at a later stage.

Builds on top of #156 