### PR TITLE
Improve DNS response parser to limit recursion for compressed labels

### DIFF
--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -301,7 +301,13 @@ final class Parser
         );
     }
 
-    private function readLabels($data, $consumed)
+    /**
+     * @param string $data
+     * @param int    $consumed
+     * @param int    $compressionDepth maximum depth for compressed labels to avoid unreasonable recursion
+     * @return array
+     */
+    private function readLabels($data, $consumed, $compressionDepth = 127)
     {
         $labels = array();
 
@@ -319,14 +325,14 @@ final class Parser
             }
 
             // first two bits set? this is a compressed label (14 bit pointer offset)
-            if (($length & 0xc0) === 0xc0 && isset($data[$consumed + 1])) {
+            if (($length & 0xc0) === 0xc0 && isset($data[$consumed + 1]) && $compressionDepth) {
                 $offset = ($length & ~0xc0) << 8 | \ord($data[$consumed + 1]);
                 if ($offset >= $consumed) {
                     return array(null, null);
                 }
 
                 $consumed += 2;
-                list($newLabels) = $this->readLabels($data, $offset);
+                list($newLabels) = $this->readLabels($data, $offset, $compressionDepth - 1);
 
                 if ($newLabels === null) {
                     return array(null, null);

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -811,6 +811,18 @@ class ParserTest extends TestCase
         $this->parser->parseMessage($data);
     }
 
+    public function testParseInvalidOffsetPointerToPreviousLabelInQuestionNameThrows()
+    {
+        $data = "";
+        $data .= "72 62 01 00 00 01 00 00 00 00 00 00"; // header
+        $data .= "02 69 6f c0 0c";          // question: offset pointer to previous label
+
+        $data = $this->convertTcpDumpToBinary($data);
+
+        $this->setExpectedException('InvalidArgumentException');
+        $this->parser->parseMessage($data);
+    }
+
     public function testParseInvalidOffsetPointerToStartOfMessageInQuestionNameThrows()
     {
         $data = "";


### PR DESCRIPTION
This changeset improves the DNS response parser to limit recursion for compressed labels. This prevents a possible infinite recursion in malformed DNS response messages. The maximum recursion depth is limited to 127 labels, matching the maximum host name length of 255 permitted as per DNS specs.

- https://tools.ietf.org/html/rfc1035#section-4.1.4
- https://serverfault.com/questions/1007283/multiple-levels-of-dns-name-compression
- https://serverfault.com/questions/580249/is-there-a-maximum-subdomain-depth

Builds on top of #115
Refs #114