### PR TITLE
Improve error handling when sending data to DNS server fails (macOS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,19 @@ jobs:
       - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
 
+  PHPUnit-macOS:
+    name: PHPUnit (macOS)
+    runs-on: macos-10.15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          coverage: xdebug
+      - run: composer install
+      - run: vendor/bin/phpunit --coverage-text
+
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
     runs-on: ubuntu-18.04

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -93,6 +93,13 @@ final class UdpTransportExecutor implements ExecutorInterface
     private $dumper;
 
     /**
+     * maximum UDP packet size to send and receive
+     *
+     * @var int
+     */
+    private $maxPacketSize = 512;
+
+    /**
      * @param string        $nameserver
      * @param LoopInterface $loop
      */
@@ -119,7 +126,7 @@ final class UdpTransportExecutor implements ExecutorInterface
         $request = Message::createRequestForQuery($query);
 
         $queryData = $this->dumper->toBinary($request);
-        if (isset($queryData[512])) {
+        if (isset($queryData[$this->maxPacketSize])) {
             return \React\Promise\reject(new \RuntimeException(
                 'DNS query for ' . $query->name . ' failed: Query too large for UDP transport',
                 \defined('SOCKET_EMSGSIZE') ? \SOCKET_EMSGSIZE : 90
@@ -142,14 +149,14 @@ final class UdpTransportExecutor implements ExecutorInterface
         if ($written !== \strlen($queryData)) {
             // Write may potentially fail, but most common errors are already caught by connection check above.
             // Among others, macOS is known to report here when trying to send to broadcast address.
-            // @codeCoverageIgnoreStart
+            // This can also be reproduced by writing data exceeding `stream_set_chunk_size()` to a server refusing UDP data.
+            // fwrite(): send of 8192 bytes failed with errno=111 Connection refused
             $error = \error_get_last();
             \preg_match('/errno=(\d+) (.+)/', $error['message'], $m);
             return \React\Promise\reject(new \RuntimeException(
                 'DNS query for ' . $query->name . ' failed: Unable to send query to DNS server ('  . (isset($m[2]) ? $m[2] : $error['message']) . ')',
                 isset($m[1]) ? (int) $m[1] : 0
             ));
-            // @codeCoverageIgnoreEnd
         }
 
         $loop = $this->loop;
@@ -161,11 +168,12 @@ final class UdpTransportExecutor implements ExecutorInterface
             throw new CancellationException('DNS query for ' . $query->name . ' has been cancelled');
         });
 
+        $max = $this->maxPacketSize;
         $parser = $this->parser;
-        $loop->addReadStream($socket, function ($socket) use ($loop, $deferred, $query, $parser, $request) {
+        $loop->addReadStream($socket, function ($socket) use ($loop, $deferred, $query, $parser, $request, $max) {
             // try to read a single data packet from the DNS server
             // ignoring any errors, this is uses UDP packets and not a stream of data
-            $data = @\fread($socket, 512);
+            $data = @\fread($socket, $max);
 
             try {
                 $response = $parser->parseMessage($data);

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -174,6 +174,9 @@ final class UdpTransportExecutor implements ExecutorInterface
             // try to read a single data packet from the DNS server
             // ignoring any errors, this is uses UDP packets and not a stream of data
             $data = @\fread($socket, $max);
+            if ($data === false) {
+                return;
+            }
 
             try {
                 $response = $parser->parseMessage($data);

--- a/tests/Query/UdpTransportExecutorTest.php
+++ b/tests/Query/UdpTransportExecutorTest.php
@@ -158,6 +158,39 @@ class UdpTransportExecutorTest extends TestCase
         throw $exception;
     }
 
+    public function testQueryKeepsPendingIfReadFailsBecauseServerRefusesConnection()
+    {
+        $socket = null;
+        $callback = null;
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addReadStream')->with($this->callback(function ($ref) use (&$socket) {
+            $socket = $ref;
+            return true;
+        }), $this->callback(function ($ref) use (&$callback) {
+            $callback = $ref;
+            return true;
+        }));
+
+        $executor = new UdpTransportExecutor('0.0.0.0', $loop);
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+        $promise = $executor->query($query);
+
+        $this->assertNotNull($socket);
+        $callback($socket);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+
+        $pending = true;
+        $promise->then(function () use (&$pending) {
+            $pending = false;
+        }, function () use (&$pending) {
+            $pending = false;
+        });
+
+        $this->assertTrue($pending);
+    }
+
     /**
      * @group internet
      */
@@ -175,27 +208,6 @@ class UdpTransportExecutorTest extends TestCase
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
         $promise->then(null, $this->expectCallableOnce());
-    }
-
-    public function testQueryKeepsPendingIfServerRejectsNetworkPacket()
-    {
-        $loop = Factory::create();
-
-        $executor = new UdpTransportExecutor('127.0.0.1:1', $loop);
-
-        $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
-
-        $wait = true;
-        $promise = $executor->query($query)->then(
-            null,
-            function ($e) use (&$wait) {
-                $wait = false;
-                throw $e;
-            }
-        );
-
-        \Clue\React\Block\sleep(0.2, $loop);
-        $this->assertTrue($wait);
     }
 
     public function testQueryKeepsPendingIfServerSendsInvalidMessage()


### PR DESCRIPTION
This changeset improves error handling when sending data to the DNS server fails. This is a quite rare error condition but something that can be reproduced when using faulty DNS server entries on macOS (e.g. https://github.com/beyondcode/expose/issues/25#issuecomment-647367304).

Together with @SimonFrings, I'm currently in the process of migrating from Travis to GitHub actions and improving our test matrix. We've noticed a similar error in the (upcoming) PR for the socket component on macOS only, so I figured it's a good idea to address this upstream (here) instead.

Builds on top of #170 and https://github.com/reactphp/stream/pull/157