### PR TITLE
Improve error handling when sending TCP/IP data to DNS server fails (macOS)

### DIFF
--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -247,6 +247,14 @@ class TcpTransportExecutorTest extends TestCase
 
     public function testQueryStaysPendingWhenClientCanNotSendExcessiveMessageInOneChunkWhenServerClosesSocket()
     {
+        if (PHP_OS === 'Darwin') {
+            // Skip on macOS because it exhibits what looks like a kernal race condition when sending excessive data to a socket that is about to shut down (EPROTOTYPE)
+            // Due to this race condition, this is somewhat flaky. Happens around 75% of the time, use `--repeat=100` to reproduce.
+            // fwrite(): Send of 4260000 bytes failed with errno=41 Protocol wrong type for socket
+            // @link http://erickt.github.io/blog/2014/11/19/adventures-in-debugging-a-potential-osx-kernel-bug/
+            $this->markTestSkipped('Skipped on macOS due to possible race condition');
+        }
+
         $writableCallback = null;
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->once())->method('addWriteStream')->with($this->anything(), $this->callback(function ($cb) use (&$writableCallback) {
@@ -262,10 +270,10 @@ class TcpTransportExecutorTest extends TestCase
         $address = stream_socket_get_name($server, false);
         $executor = new TcpTransportExecutor($address, $loop);
 
-        $query = new Query('google' . str_repeat('.com', 10000), Message::TYPE_A, Message::CLASS_IN);
+        $query = new Query('google' . str_repeat('.com', 100), Message::TYPE_A, Message::CLASS_IN);
 
         // send a bunch of queries and keep reference to last promise
-        for ($i = 0; $i < 100; ++$i) {
+        for ($i = 0; $i < 2000; ++$i) {
             $promise = $executor->query($query);
         }
 

--- a/tests/Query/UdpTransportExecutorTest.php
+++ b/tests/Query/UdpTransportExecutorTest.php
@@ -153,7 +153,7 @@ class UdpTransportExecutorTest extends TestCase
             $exception = $reason;
         });
 
-        // ECONNREFUSED( Connection refused) on Linux, EMSGSIZE (Message too long) on macOS
+        // ECONNREFUSED (Connection refused) on Linux, EMSGSIZE (Message too long) on macOS
         $this->setExpectedException('RuntimeException', 'Unable to send query to DNS server');
         throw $exception;
     }


### PR DESCRIPTION
This changeset improves error handling when sending TCP/IP data to DNS server fails. This is a somewhat expected error condition as exhibited in our test suite. Additionally, there's a somewhat flaky error condition that can only be reproduced in some cases due to a kernel race condition on macOS.

Here's a quick link dump that describes this potential race condition in greater detail in other projects:

* http://erickt.github.io/blog/2014/11/19/adventures-in-debugging-a-potential-osx-kernel-bug/
* https://stackoverflow.com/questions/59914608/error-with-tcp-send-in-python-protocol-wrong-type-for-socket
* https://github.com/swift-server/async-http-client/issues/322
* https://github.com/apple/swift-nio/pull/1706 / https://github.com/apple/swift-nio/pull/1707

The gist is that with these changes applied, our test suite now works reliably also on macOS. Additionally, we include more error details to show the particular errno/errstr that caused the error, so this is something that benefits all platforms.

Together with #171, you're looking at ~16h of work. Hunting kernel race conditions is fun.

Builds on top of #171 