### PR TITLE
Improve error reporting when query fails, include domain and query type and DNS server address where applicable

### DIFF
--- a/examples/92-query-any.php
+++ b/examples/92-query-any.php
@@ -73,7 +73,7 @@ $executor->query($any)->then(function (Message $message) {
                 break;
             default:
                 // unknown type uses HEX format
-                $type = 'Type ' . $answer->type;
+                $type = 'TYPE' . $answer->type;
                 $data = wordwrap(strtoupper(bin2hex($data)), 2, ' ', true);
         }
 

--- a/src/Query/CachingExecutor.php
+++ b/src/Query/CachingExecutor.php
@@ -57,7 +57,7 @@ final class CachingExecutor implements ExecutorInterface
                 $pending = null;
             });
         }, function ($_, $reject) use (&$pending, $query) {
-            $reject(new \RuntimeException('DNS query for ' . $query->name . ' has been cancelled'));
+            $reject(new \RuntimeException('DNS query for ' . $query->describe() . ' has been cancelled'));
             $pending->cancel();
             $pending = null;
         });

--- a/src/Query/CoopExecutor.php
+++ b/src/Query/CoopExecutor.php
@@ -81,7 +81,7 @@ final class CoopExecutor implements ExecutorInterface
                 $promise->cancel();
                 $promise = null;
             }
-            throw new \RuntimeException('DNS query for ' . $query->name . ' has been cancelled');
+            throw new \RuntimeException('DNS query for ' . $query->describe() . ' has been cancelled');
         });
     }
 

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -2,6 +2,8 @@
 
 namespace React\Dns\Query;
 
+use React\Dns\Model\Message;
+
 /**
  * This class represents a single question in a query/response message
  *
@@ -38,5 +40,30 @@ final class Query
         $this->name = $name;
         $this->type = $type;
         $this->class = $class;
+    }
+
+    /**
+     * Describes the hostname and query type/class for this query
+     *
+     * The output format is supposed to be human readable and is subject to change.
+     * The format is inspired by RFC 3597 when handling unkown types/classes.
+     *
+     * @return string "example.com (A)" or "example.com (CLASS0 TYPE1234)"
+     * @link https://tools.ietf.org/html/rfc3597
+     */
+    public function describe()
+    {
+        $class = $this->class !== Message::CLASS_IN ? 'CLASS' . $this->class . ' ' : '';
+
+        $type = 'TYPE' . $this->type;
+        $ref = new \ReflectionClass('React\Dns\Model\Message');
+        foreach ($ref->getConstants() as $name => $value) {
+            if ($value === $this->type && \strpos($name, 'TYPE_') === 0) {
+                $type = \substr($name, 5);
+                break;
+            }
+        }
+
+        return $this->name . ' (' . $class . $type . ')';
     }
 }

--- a/src/Query/RetryExecutor.php
+++ b/src/Query/RetryExecutor.php
@@ -43,7 +43,7 @@ final class RetryExecutor implements ExecutorInterface
             } elseif ($retries <= 0) {
                 $errorback = null;
                 $deferred->reject($e = new \RuntimeException(
-                    'DNS query for ' . $query->name . ' failed: too many retries',
+                    'DNS query for ' . $query->describe() . ' failed: too many retries',
                     0,
                     $e
                 ));

--- a/src/Query/TcpTransportExecutor.php
+++ b/src/Query/TcpTransportExecutor.php
@@ -147,7 +147,7 @@ class TcpTransportExecutor implements ExecutorInterface
             throw new \InvalidArgumentException('Invalid nameserver address given');
         }
 
-        $this->nameserver = $parts['host'] . ':' . (isset($parts['port']) ? $parts['port'] : 53);
+        $this->nameserver = 'tcp://' . $parts['host'] . ':' . (isset($parts['port']) ? $parts['port'] : 53);
         $this->loop = $loop;
         $this->parser = new Parser();
         $this->dumper = new BinaryDumper();
@@ -177,7 +177,7 @@ class TcpTransportExecutor implements ExecutorInterface
             $socket = @\stream_socket_client($this->nameserver, $errno, $errstr, 0, \STREAM_CLIENT_CONNECT | \STREAM_CLIENT_ASYNC_CONNECT);
             if ($socket === false) {
                 return \React\Promise\reject(new \RuntimeException(
-                    'DNS query for ' . $query->describe() . ' failed: Unable to connect to DNS server ('  . $errstr . ')',
+                    'DNS query for ' . $query->describe() . ' failed: Unable to connect to DNS server ' . $this->nameserver . ' ('  . $errstr . ')',
                     $errno
                 ));
             }
@@ -227,7 +227,7 @@ class TcpTransportExecutor implements ExecutorInterface
         if ($this->readPending === false) {
             $name = @\stream_socket_get_name($this->socket, true);
             if ($name === false) {
-                $this->closeError('Connection to DNS server rejected');
+                $this->closeError('Connection to DNS server ' . $this->nameserver . ' rejected');
                 return;
             }
 
@@ -240,7 +240,7 @@ class TcpTransportExecutor implements ExecutorInterface
             $error = \error_get_last();
             \preg_match('/errno=(\d+) (.+)/', $error['message'], $m);
             $this->closeError(
-                'Unable to send query to DNS server (' . (isset($m[2]) ? $m[2] : $error['message']) . ')',
+                'Unable to send query to DNS server ' . $this->nameserver . ' (' . (isset($m[2]) ? $m[2] : $error['message']) . ')',
                 isset($m[1]) ? (int) $m[1] : 0
             );
             return;
@@ -264,7 +264,7 @@ class TcpTransportExecutor implements ExecutorInterface
         // any error is fatal, this is a stream of TCP/IP data
         $chunk = @\fread($this->socket, 65536);
         if ($chunk === false || $chunk === '') {
-            $this->closeError('Connection to DNS server lost');
+            $this->closeError('Connection to DNS server ' . $this->nameserver . ' lost');
             return;
         }
 
@@ -286,13 +286,13 @@ class TcpTransportExecutor implements ExecutorInterface
                 $response = $this->parser->parseMessage($data);
             } catch (\Exception $e) {
                 // reject all pending queries if we received an invalid message from remote server
-                $this->closeError('Invalid message received from DNS server');
+                $this->closeError('Invalid message received from DNS server ' . $this->nameserver);
                 return;
             }
 
             // reject all pending queries if we received an unexpected response ID or truncated response
             if (!isset($this->pending[$response->id]) || $response->tc) {
-                $this->closeError('Invalid response message received from DNS server');
+                $this->closeError('Invalid response message received from DNS server ' . $this->nameserver);
                 return;
             }
 

--- a/src/Query/TcpTransportExecutor.php
+++ b/src/Query/TcpTransportExecutor.php
@@ -166,7 +166,7 @@ class TcpTransportExecutor implements ExecutorInterface
         $length = \strlen($queryData);
         if ($length > 0xffff) {
             return \React\Promise\reject(new \RuntimeException(
-                'DNS query for ' . $query->name . ' failed: Query too large for TCP transport'
+                'DNS query for ' . $query->describe() . ' failed: Query too large for TCP transport'
             ));
         }
 
@@ -177,7 +177,7 @@ class TcpTransportExecutor implements ExecutorInterface
             $socket = @\stream_socket_client($this->nameserver, $errno, $errstr, 0, \STREAM_CLIENT_CONNECT | \STREAM_CLIENT_ASYNC_CONNECT);
             if ($socket === false) {
                 return \React\Promise\reject(new \RuntimeException(
-                    'DNS query for ' . $query->name . ' failed: Unable to connect to DNS server ('  . $errstr . ')',
+                    'DNS query for ' . $query->describe() . ' failed: Unable to connect to DNS server ('  . $errstr . ')',
                     $errno
                 ));
             }
@@ -214,7 +214,7 @@ class TcpTransportExecutor implements ExecutorInterface
         });
 
         $this->pending[$request->id] = $deferred;
-        $this->names[$request->id] = $query->name;
+        $this->names[$request->id] = $query->describe();
 
         return $deferred->promise();
     }

--- a/src/Query/TimeoutExecutor.php
+++ b/src/Query/TimeoutExecutor.php
@@ -22,7 +22,7 @@ final class TimeoutExecutor implements ExecutorInterface
     {
         return Timer\timeout($this->executor->query($query), $this->timeout, $this->loop)->then(null, function ($e) use ($query) {
             if ($e instanceof Timer\TimeoutException) {
-                $e = new TimeoutException(sprintf("DNS query for %s timed out", $query->name), 0, $e);
+                $e = new TimeoutException(sprintf("DNS query for %s timed out", $query->describe()), 0, $e);
             }
             throw $e;
         });

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -128,7 +128,7 @@ final class UdpTransportExecutor implements ExecutorInterface
         $queryData = $this->dumper->toBinary($request);
         if (isset($queryData[$this->maxPacketSize])) {
             return \React\Promise\reject(new \RuntimeException(
-                'DNS query for ' . $query->name . ' failed: Query too large for UDP transport',
+                'DNS query for ' . $query->describe() . ' failed: Query too large for UDP transport',
                 \defined('SOCKET_EMSGSIZE') ? \SOCKET_EMSGSIZE : 90
             ));
         }
@@ -137,7 +137,7 @@ final class UdpTransportExecutor implements ExecutorInterface
         $socket = @\stream_socket_client($this->nameserver, $errno, $errstr, 0);
         if ($socket === false) {
             return \React\Promise\reject(new \RuntimeException(
-                'DNS query for ' . $query->name . ' failed: Unable to connect to DNS server ('  . $errstr . ')',
+                'DNS query for ' . $query->describe() . ' failed: Unable to connect to DNS server ('  . $errstr . ')',
                 $errno
             ));
         }
@@ -154,7 +154,7 @@ final class UdpTransportExecutor implements ExecutorInterface
             $error = \error_get_last();
             \preg_match('/errno=(\d+) (.+)/', $error['message'], $m);
             return \React\Promise\reject(new \RuntimeException(
-                'DNS query for ' . $query->name . ' failed: Unable to send query to DNS server ('  . (isset($m[2]) ? $m[2] : $error['message']) . ')',
+                'DNS query for ' . $query->describe() . ' failed: Unable to send query to DNS server ('  . (isset($m[2]) ? $m[2] : $error['message']) . ')',
                 isset($m[1]) ? (int) $m[1] : 0
             ));
         }
@@ -165,7 +165,7 @@ final class UdpTransportExecutor implements ExecutorInterface
             $loop->removeReadStream($socket);
             \fclose($socket);
 
-            throw new CancellationException('DNS query for ' . $query->name . ' has been cancelled');
+            throw new CancellationException('DNS query for ' . $query->describe() . ' has been cancelled');
         });
 
         $max = $this->maxPacketSize;
@@ -198,7 +198,7 @@ final class UdpTransportExecutor implements ExecutorInterface
 
             if ($response->tc) {
                 $deferred->reject(new \RuntimeException(
-                    'DNS query for ' . $query->name . ' failed: The server returned a truncated result for a UDP query',
+                    'DNS query for ' . $query->describe() . ' failed: The server returned a truncated result for a UDP query',
                     \defined('SOCKET_EMSGSIZE') ? \SOCKET_EMSGSIZE : 90
                 ));
                 return;

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -137,7 +137,7 @@ final class UdpTransportExecutor implements ExecutorInterface
         $socket = @\stream_socket_client($this->nameserver, $errno, $errstr, 0);
         if ($socket === false) {
             return \React\Promise\reject(new \RuntimeException(
-                'DNS query for ' . $query->describe() . ' failed: Unable to connect to DNS server ('  . $errstr . ')',
+                'DNS query for ' . $query->describe() . ' failed: Unable to connect to DNS server ' . $this->nameserver . ' ('  . $errstr . ')',
                 $errno
             ));
         }
@@ -154,7 +154,7 @@ final class UdpTransportExecutor implements ExecutorInterface
             $error = \error_get_last();
             \preg_match('/errno=(\d+) (.+)/', $error['message'], $m);
             return \React\Promise\reject(new \RuntimeException(
-                'DNS query for ' . $query->describe() . ' failed: Unable to send query to DNS server ('  . (isset($m[2]) ? $m[2] : $error['message']) . ')',
+                'DNS query for ' . $query->describe() . ' failed: Unable to send query to DNS server ' . $this->nameserver . ' ('  . (isset($m[2]) ? $m[2] : $error['message']) . ')',
                 isset($m[1]) ? (int) $m[1] : 0
             ));
         }
@@ -170,7 +170,8 @@ final class UdpTransportExecutor implements ExecutorInterface
 
         $max = $this->maxPacketSize;
         $parser = $this->parser;
-        $loop->addReadStream($socket, function ($socket) use ($loop, $deferred, $query, $parser, $request, $max) {
+        $nameserver = $this->nameserver;
+        $loop->addReadStream($socket, function ($socket) use ($loop, $deferred, $query, $parser, $request, $max, $nameserver) {
             // try to read a single data packet from the DNS server
             // ignoring any errors, this is uses UDP packets and not a stream of data
             $data = @\fread($socket, $max);
@@ -198,7 +199,7 @@ final class UdpTransportExecutor implements ExecutorInterface
 
             if ($response->tc) {
                 $deferred->reject(new \RuntimeException(
-                    'DNS query for ' . $query->describe() . ' failed: The server returned a truncated result for a UDP query',
+                    'DNS query for ' . $query->describe() . ' failed: The DNS server ' . $nameserver . ' returned a truncated result for a UDP query',
                     \defined('SOCKET_EMSGSIZE') ? \SOCKET_EMSGSIZE : 90
                 ));
                 return;

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -72,7 +72,7 @@ final class Resolver implements ResolverInterface
                     $message = 'Unknown error response code ' . $code;
             }
             throw new RecordNotFoundException(
-                'DNS query for ' . $query->name . ' returned an error response (' . $message . ')',
+                'DNS query for ' . $query->describe() . ' returned an error response (' . $message . ')',
                 $code
             );
         }
@@ -83,7 +83,7 @@ final class Resolver implements ResolverInterface
         // reject if we did not receive a valid answer (domain is valid, but no record for this type could be found)
         if (0 === count($addresses)) {
             throw new RecordNotFoundException(
-                'DNS query for ' . $query->name . ' did not return a valid answer (NOERROR / NODATA)'
+                'DNS query for ' . $query->describe() . ' did not return a valid answer (NOERROR / NODATA)'
             );
         }
 

--- a/tests/Query/CoopExecutorTest.php
+++ b/tests/Query/CoopExecutorTest.php
@@ -127,7 +127,14 @@ class CoopExecutorTest extends TestCase
 
         $promise->cancel();
 
-        $promise->then(null, $this->expectCallableOnce());
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        /** @var \RuntimeException $exception */
+        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertEquals('DNS query for reactphp.org (A) has been cancelled', $exception->getMessage());
     }
 
     public function testCancelOneQueryWhenOtherQueryIsStillPendingWillNotCancelPromiseFromBaseExecutorAndRejectCancelled()

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace React\Tests\Dns\Query;
+
+use React\Dns\Model\Message;
+use React\Dns\Query\Query;
+use React\Tests\Dns\TestCase;
+
+class QueryTest extends TestCase
+{
+    public function testDescribeSimpleAQuery()
+    {
+        $query = new Query('example.com', Message::TYPE_A, Message::CLASS_IN);
+
+        $this->assertEquals('example.com (A)', $query->describe());
+    }
+
+    public function testDescribeUnknownType()
+    {
+        $query = new Query('example.com', 0, 0);
+
+        $this->assertEquals('example.com (CLASS0 TYPE0)', $query->describe());
+    }
+}

--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -265,7 +265,8 @@ class TcpTransportExecutorTest extends TestCase
 
         /** @var \RuntimeException $exception */
         $this->assertInstanceOf('RuntimeException', $exception);
-        $this->assertEquals('DNS query for google.com (A) failed: Connection to DNS server tcp://127.0.0.1:1 rejected', $exception->getMessage());
+        $this->assertEquals('DNS query for google.com (A) failed: Unable to connect to DNS server tcp://127.0.0.1:1 (Connection refused)', $exception->getMessage());
+        $this->assertEquals(defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $exception->getCode());
     }
 
     public function testQueryStaysPendingWhenClientCanNotSendExcessiveMessageInOneChunk()

--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -94,12 +94,22 @@ class TcpTransportExecutorTest extends TestCase
         $query = new Query('google.' . str_repeat('.com', 60000), Message::TYPE_A, Message::CLASS_IN);
         $promise = $executor->query($query);
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
-        $promise->then(null, $this->expectCallableOnce());
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        /** @var \RuntimeException $exception */
+        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertEquals('DNS query for '. $query->name . ' (A) failed: Query too large for TCP transport', $exception->getMessage());
     }
 
     public function testQueryRejectsIfServerConnectionFails()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM reports different error message for invalid addresses');
+        }
+
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->never())->method('addWriteStream');
 
@@ -112,8 +122,14 @@ class TcpTransportExecutorTest extends TestCase
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
         $promise = $executor->query($query);
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
-        $promise->then(null, $this->expectCallableOnce());
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        /** @var \RuntimeException $exception */
+        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertEquals('DNS query for google.com (A) failed: Unable to connect to DNS server (Failed to parse address "///")', $exception->getMessage());
     }
 
     public function testQueryRejectsOnCancellationWithoutClosingSocketButStartsIdleTimer()
@@ -137,8 +153,14 @@ class TcpTransportExecutorTest extends TestCase
         $promise = $executor->query($query);
         $promise->cancel();
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
-        $promise->then(null, $this->expectCallableOnce());
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        /** @var \React\Dns\Query\CancellationException $exception */
+        $this->assertInstanceOf('React\Dns\Query\CancellationException', $exception);
+        $this->assertEquals('DNS query for google.com (A) has been cancelled', $exception->getMessage());
     }
 
     public function testTriggerIdleTimerAfterQueryRejectedOnCancellationWillCloseSocket()
@@ -228,21 +250,22 @@ class TcpTransportExecutorTest extends TestCase
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
 
-        $wait = true;
+        $exception = null;
         $executor->query($query)->then(
             null,
-            function ($e) use (&$wait) {
-                $wait = false;
-                throw $e;
+            function ($e) use (&$exception) {
+                $exception = $e;
             }
         );
 
         \Clue\React\Block\sleep(0.01, $loop);
-        if ($wait) {
+        if ($exception === null) {
             \Clue\React\Block\sleep(0.2, $loop);
         }
 
-        $this->assertFalse($wait);
+        /** @var \RuntimeException $exception */
+        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertEquals('DNS query for google.com (A) failed: Connection to DNS server rejected', $exception->getMessage());
     }
 
     public function testQueryStaysPendingWhenClientCanNotSendExcessiveMessageInOneChunk()

--- a/tests/Query/TimeoutExecutorTest.php
+++ b/tests/Query/TimeoutExecutorTest.php
@@ -105,7 +105,7 @@ class TimeoutExecutorTest extends TestCase
             \Clue\React\Block\await($promise, $this->loop);
             $this->fail();
         } catch (TimeoutException $exception) {
-            $this->assertEquals('DNS query for igor.io timed out' , $exception->getMessage());
+            $this->assertEquals('DNS query for igor.io (A) timed out' , $exception->getMessage());
         }
 
         $this->assertEquals(1, $cancelled);

--- a/tests/Query/UdpTransportExecutorTest.php
+++ b/tests/Query/UdpTransportExecutorTest.php
@@ -136,7 +136,7 @@ class UdpTransportExecutorTest extends TestCase
 
         $this->setExpectedException(
             'RuntimeException',
-            'DNS query for google.com (A) failed: Unable to connect to DNS server (Failed to parse address "///")'
+            'DNS query for google.com (A) failed: Unable to connect to DNS server /// (Failed to parse address "///")'
         );
         throw $exception;
     }
@@ -166,7 +166,7 @@ class UdpTransportExecutorTest extends TestCase
         // ECONNREFUSED (Connection refused) on Linux, EMSGSIZE (Message too long) on macOS
         $this->setExpectedException(
             'RuntimeException',
-            'DNS query for ' . $query->name . ' (A) failed: Unable to send query to DNS server'
+            'DNS query for ' . $query->name . ' (A) failed: Unable to send query to DNS server udp://0.0.0.0:53 ('
         );
         throw $exception;
     }
@@ -318,7 +318,7 @@ class UdpTransportExecutorTest extends TestCase
 
         $this->setExpectedException(
             'RuntimeException',
-            'DNS query for google.com (A) failed: The server returned a truncated result for a UDP query',
+            'DNS query for google.com (A) failed: The DNS server udp://' . $address . ' returned a truncated result for a UDP query',
             defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90
         );
         \Clue\React\Block\await($promise, $loop, 0.1);

--- a/tests/Query/UdpTransportExecutorTest.php
+++ b/tests/Query/UdpTransportExecutorTest.php
@@ -101,12 +101,20 @@ class UdpTransportExecutorTest extends TestCase
             $exception = $reason;
         });
 
-        $this->setExpectedException('RuntimeException', '', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90);
+        $this->setExpectedException(
+            'RuntimeException',
+            'DNS query for ' . $query->name . ' (A) failed: Query too large for UDP transport',
+            defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90
+        );
         throw $exception;
     }
 
     public function testQueryRejectsIfServerConnectionFails()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM reports different error message for invalid addresses');
+        }
+
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->never())->method('addReadStream');
 
@@ -126,8 +134,10 @@ class UdpTransportExecutorTest extends TestCase
             $exception = $reason;
         });
 
-        // PHP (Failed to parse address "///") differs from HHVM (Name or service not known)
-        $this->setExpectedException('RuntimeException', 'Unable to connect to DNS server');
+        $this->setExpectedException(
+            'RuntimeException',
+            'DNS query for google.com (A) failed: Unable to connect to DNS server (Failed to parse address "///")'
+        );
         throw $exception;
     }
 
@@ -154,7 +164,10 @@ class UdpTransportExecutorTest extends TestCase
         });
 
         // ECONNREFUSED (Connection refused) on Linux, EMSGSIZE (Message too long) on macOS
-        $this->setExpectedException('RuntimeException', 'Unable to send query to DNS server');
+        $this->setExpectedException(
+            'RuntimeException',
+            'DNS query for ' . $query->name . ' (A) failed: Unable to send query to DNS server'
+        );
         throw $exception;
     }
 
@@ -206,8 +219,14 @@ class UdpTransportExecutorTest extends TestCase
         $promise = $executor->query($query);
         $promise->cancel();
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
-        $promise->then(null, $this->expectCallableOnce());
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        /** @var \React\Dns\Query\CancellationException $exception */
+        $this->assertInstanceOf('React\Dns\Query\CancellationException', $exception);
+        $this->assertEquals('DNS query for google.com (A) has been cancelled', $exception->getMessage());
     }
 
     public function testQueryKeepsPendingIfServerSendsInvalidMessage()
@@ -297,7 +316,11 @@ class UdpTransportExecutorTest extends TestCase
 
         $promise = $executor->query($query);
 
-        $this->setExpectedException('RuntimeException', '', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90);
+        $this->setExpectedException(
+            'RuntimeException',
+            'DNS query for google.com (A) failed: The server returned a truncated result for a UDP query',
+            defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90
+        );
         \Clue\React\Block\await($promise, $loop, 0.1);
     }
 

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -164,7 +164,7 @@ class ResolverTest extends TestCase
             }));
 
         $errback = $this->expectCallableOnceWith($this->callback(function ($param) {
-            return ($param instanceof RecordNotFoundException && $param->getCode() === 0 && $param->getMessage() === 'DNS query for igor.io did not return a valid answer (NOERROR / NODATA)');
+            return ($param instanceof RecordNotFoundException && $param->getCode() === 0 && $param->getMessage() === 'DNS query for igor.io (A) did not return a valid answer (NOERROR / NODATA)');
         }));
 
         $resolver = new Resolver($executor);
@@ -176,27 +176,27 @@ class ResolverTest extends TestCase
         return array(
             array(
                 Message::RCODE_FORMAT_ERROR,
-                'DNS query for example.com returned an error response (Format Error)',
+                'DNS query for example.com (A) returned an error response (Format Error)',
             ),
             array(
                 Message::RCODE_SERVER_FAILURE,
-                'DNS query for example.com returned an error response (Server Failure)',
+                'DNS query for example.com (A) returned an error response (Server Failure)',
             ),
             array(
                 Message::RCODE_NAME_ERROR,
-                'DNS query for example.com returned an error response (Non-Existent Domain / NXDOMAIN)'
+                'DNS query for example.com (A) returned an error response (Non-Existent Domain / NXDOMAIN)'
             ),
             array(
                 Message::RCODE_NOT_IMPLEMENTED,
-                'DNS query for example.com returned an error response (Not Implemented)'
+                'DNS query for example.com (A) returned an error response (Not Implemented)'
             ),
             array(
                 Message::RCODE_REFUSED,
-                'DNS query for example.com returned an error response (Refused)'
+                'DNS query for example.com (A) returned an error response (Refused)'
             ),
             array(
                 99,
-                'DNS query for example.com returned an error response (Unknown error response code 99)'
+                'DNS query for example.com (A) returned an error response (Unknown error response code 99)'
             )
         );
     }


### PR DESCRIPTION
This changeset improves error reporting when a query fails. The exception message now always includes domain and query type and the DNS server address where applicable.

For example:

```diff
- DNS query for google.com failed: Connection to DNS server rejected
+ DNS query for google.com (AAAA) failed: Unable to connect to DNS server tcp://8.8.8.8:53 (No route to host)
```

This makes it much easier to debug in case of an error (#173, https://github.com/reactphp/socket/pull/230, https://github.com/beyondcode/expose/issues/25 and others). Additionally, I consider this to be a prerequisite for future multiple DNS servers (#6) that will be added in a follow-up PR. This is pure future addition that works across all supported platforms and does not affect BC.

Builds on top of #171 and #172