### PR TITLE
Add createFromConfig factory methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,8 @@ names, baby!
 ```php
 $loop = React\EventLoop\Factory::create();
 
-$config = React\Dns\Config\Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
-
 $factory = new React\Dns\Resolver\Factory();
-$dns = $factory->create($server, $loop);
+$dns = $factory->createFromConfig(React\Dns\Config\Config::loadSystemConfigBlocking(), $loop, '8.8.8.8');
 
 $dns->resolve('igor.io')->then(function ($ip) {
     echo "Host: $ip\n";
@@ -72,11 +69,8 @@ You can cache results by configuring the resolver to use a `CachedExecutor`:
 ```php
 $loop = React\EventLoop\Factory::create();
 
-$config = React\Dns\Config\Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
-
 $factory = new React\Dns\Resolver\Factory();
-$dns = $factory->createCached($server, $loop);
+$dns = $factory->createCachedFromConfig(React\Dns\Config\Config::loadSystemConfigBlocking(), $loop, '8.8.8.8');
 
 $dns->resolve('igor.io')->then(function ($ip) {
     echo "Host: $ip\n";

--- a/examples/01-one.php
+++ b/examples/01-one.php
@@ -7,11 +7,8 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
-$config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
-
 $factory = new Factory();
-$resolver = $factory->create($server, $loop);
+$resolver = $factory->createFromConfig(Config::loadSystemConfigBlocking(), $loop, '8.8.8.8');
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 

--- a/examples/02-concurrent.php
+++ b/examples/02-concurrent.php
@@ -7,11 +7,8 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
-$config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
-
 $factory = new Factory();
-$resolver = $factory->create($server, $loop);
+$resolver = $factory->createFromConfig(Config::loadSystemConfigBlocking(), $loop, '8.8.8.8');
 
 $names = array_slice($argv, 1);
 if (!$names) {

--- a/examples/03-cached.php
+++ b/examples/03-cached.php
@@ -7,11 +7,8 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
-$config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
-
 $factory = new Factory();
-$resolver = $factory->createCached($server, $loop);
+$resolver = $factory->createCachedFromConfig(Config::loadSystemConfigBlocking(), $loop, '8.8.8.8');
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 

--- a/examples/11-all-ips.php
+++ b/examples/11-all-ips.php
@@ -8,11 +8,8 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
-$config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
-
 $factory = new Factory();
-$resolver = $factory->create($server, $loop);
+$resolver = $factory->createFromConfig(Config::loadSystemConfigBlocking(), $loop, '8.8.8.8');
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 

--- a/examples/12-all-types.php
+++ b/examples/12-all-types.php
@@ -10,11 +10,8 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
-$config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
-
 $factory = new Factory();
-$resolver = $factory->create($server, $loop);
+$resolver = $factory->createFromConfig(Config::loadSystemConfigBlocking(), $loop, '8.8.8.8');
 
 $name = isset($argv[1]) ? $argv[1] : 'google.com';
 $type = constant('React\Dns\Model\Message::TYPE_' . (isset($argv[2]) ? $argv[2] : 'TXT'));

--- a/examples/13-reverse-dns.php
+++ b/examples/13-reverse-dns.php
@@ -8,11 +8,8 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
-$config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
-
 $factory = new Factory();
-$resolver = $factory->create($server, $loop);
+$resolver = $factory->createFromConfig(Config::loadSystemConfigBlocking(), $loop, '8.8.8.8');
 
 $ip = isset($argv[1]) ? $argv[1] : '8.8.8.8';
 

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -4,6 +4,7 @@ namespace React\Dns\Resolver;
 
 use React\Cache\ArrayCache;
 use React\Cache\CacheInterface;
+use React\Dns\Config\Config;
 use React\Dns\Config\HostsFile;
 use React\Dns\Query\CachingExecutor;
 use React\Dns\Query\CoopExecutor;
@@ -18,6 +19,29 @@ use React\EventLoop\LoopInterface;
 
 final class Factory
 {
+    /**
+     * @param Config        $config
+     * @param LoopInterface $loop
+     * @param string        $fallbackNameserver
+     * @return \React\Dns\Resolver\ResolverInterface
+     */
+    public function createFromConfig(Config $config, LoopInterface $loop, $fallbackNameserver)
+    {
+        return self::create($config->nameservers ? reset($config->nameservers) : $fallbackNameserver, $loop);
+    }
+
+    /**
+     * @param Config          $config
+     * @param LoopInterface   $loop
+     * @param string          $fallbackNameserver
+     * @param ?CacheInterface $cache
+     * @return \React\Dns\Resolver\ResolverInterface
+     */
+    public function createCachedFromConfig(Config $config, LoopInterface $loop, $fallbackNameserver, CacheInterface $cache = null)
+    {
+        return self::createCached($config->nameservers ? reset($config->nameservers) : $fallbackNameserver, $loop, $cache);
+    }
+
     /**
      * @param string        $nameserver
      * @param LoopInterface $loop

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -2,12 +2,24 @@
 
 namespace React\Tests\Dns\Resolver;
 
+use React\Dns\Config\Config;
 use React\Dns\Resolver\Factory;
 use React\Tests\Dns\TestCase;
 use React\Dns\Query\HostsFileExecutor;
 
 class FactoryTest extends TestCase
 {
+    /** @test */
+    public function createFromConfigShouldCreateResolver()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $factory = new Factory();
+        $resolver = $factory->createFromConfig(Config::loadSystemConfigBlocking(), $loop, '8.8.8.8:53');
+
+        $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
+    }
+
     /** @test */
     public function createShouldCreateResolver()
     {
@@ -151,6 +163,21 @@ class FactoryTest extends TestCase
 
         $factory = new Factory();
         $resolver = $factory->createCached('8.8.8.8:53', $loop);
+
+        $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
+        $executor = $this->getResolverPrivateExecutor($resolver);
+        $this->assertInstanceOf('React\Dns\Query\CachingExecutor', $executor);
+        $cache = $this->getCachingExecutorPrivateMemberValue($executor, 'cache');
+        $this->assertInstanceOf('React\Cache\ArrayCache', $cache);
+    }
+
+    /** @test */
+    public function createCachedFromConfigShouldCreateResolverWithCachingExecutor()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $factory = new Factory();
+        $resolver = $factory->createCachedFromConfig(Config::loadSystemConfigBlocking(), $loop, '8.8.8.8:53');
 
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
         $executor = $this->getResolverPrivateExecutor($resolver);


### PR DESCRIPTION
This little bit of syntactical sugar makes it cleaner to use the Config class to load the system resolver configuration. Which right now is limited to only one nameserver. By introducing this factory method completing the implementation in #131 will also allow for instant multiple server support out of the box without any need for users to change code on their end to implement it.

Refs #131 