### PR TITLE
Fix integer overflow for TCP/IP chunk size on 32 bit platforms

### DIFF
--- a/src/Query/TcpTransportExecutor.php
+++ b/src/Query/TcpTransportExecutor.php
@@ -185,7 +185,7 @@ class TcpTransportExecutor implements ExecutorInterface
             // set socket to non-blocking and wait for it to become writable (connection success/rejected)
             \stream_set_blocking($socket, false);
             if (\function_exists('stream_set_chunk_size')) {
-                \stream_set_chunk_size($socket, (1 << 31) - 1); // @codeCoverageIgnore
+                \stream_set_chunk_size($socket, (int) ((1 << 31) - 1)); // @codeCoverageIgnore
             }
             $this->socket = $socket;
         }


### PR DESCRIPTION
This changeset fixes an integer overflow for the TCP/IP chunk size on 32 bit platforms. This does not affect common 64 bit platforms and/or the normal UDP query, so this can be rarely observed in practice.

```php
$ docker run -it --rm yukoff/php-32bit
Interactive shell

php > var_dump(PHP_INT_MAX);
int(2147483647)
php > var_dump((1 << 31));
int(-2147483648)
php > var_dump((1 << 31) - 1);
float(-2147483649)
php > var_dump((int)((1 << 31) - 1));
int(2147483647)
```

Closes #176
Builds on top of #172, in particular https://github.com/reactphp/dns/pull/172/files#diff-cde9e8c539defb086472120d9570d3cb4ca4f02924bd010e8bfce932079a5ddaR188