### PR TITLE
Update DNS `Factory` to accept complete `Config` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ names, baby!
 $loop = React\EventLoop\Factory::create();
 
 $config = React\Dns\Config\Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+if (!$config->nameservers) {
+    $config->nameservers[] = '8.8.8.8';
+}
 
 $factory = new React\Dns\Resolver\Factory();
-$dns = $factory->create($server, $loop);
+$dns = $factory->create($config, $loop);
 
 $dns->resolve('igor.io')->then(function ($ip) {
     echo "Host: $ip\n";
@@ -73,10 +75,12 @@ You can cache results by configuring the resolver to use a `CachedExecutor`:
 $loop = React\EventLoop\Factory::create();
 
 $config = React\Dns\Config\Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+if (!$config->nameservers) {
+    $config->nameservers[] = '8.8.8.8';
+}
 
 $factory = new React\Dns\Resolver\Factory();
-$dns = $factory->createCached($server, $loop);
+$dns = $factory->createCached($config, $loop);
 
 $dns->resolve('igor.io')->then(function ($ip) {
     echo "Host: $ip\n";

--- a/examples/01-one.php
+++ b/examples/01-one.php
@@ -8,10 +8,12 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+if (!$config->nameservers) {
+    $config->nameservers[] = '8.8.8.8';
+}
 
 $factory = new Factory();
-$resolver = $factory->create($server, $loop);
+$resolver = $factory->create($config, $loop);
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 

--- a/examples/02-concurrent.php
+++ b/examples/02-concurrent.php
@@ -8,10 +8,12 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+if (!$config->nameservers) {
+    $config->nameservers[] = '8.8.8.8';
+}
 
 $factory = new Factory();
-$resolver = $factory->create($server, $loop);
+$resolver = $factory->create($config, $loop);
 
 $names = array_slice($argv, 1);
 if (!$names) {

--- a/examples/03-cached.php
+++ b/examples/03-cached.php
@@ -8,10 +8,12 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+if (!$config->nameservers) {
+    $config->nameservers[] = '8.8.8.8';
+}
 
 $factory = new Factory();
-$resolver = $factory->createCached($server, $loop);
+$resolver = $factory->createCached($config, $loop);
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 

--- a/examples/11-all-ips.php
+++ b/examples/11-all-ips.php
@@ -9,10 +9,12 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+if (!$config->nameservers) {
+    $config->nameservers[] = '8.8.8.8';
+}
 
 $factory = new Factory();
-$resolver = $factory->create($server, $loop);
+$resolver = $factory->create($config, $loop);
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 

--- a/examples/12-all-types.php
+++ b/examples/12-all-types.php
@@ -11,10 +11,12 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+if (!$config->nameservers) {
+    $config->nameservers[] = '8.8.8.8';
+}
 
 $factory = new Factory();
-$resolver = $factory->create($server, $loop);
+$resolver = $factory->create($config, $loop);
 
 $name = isset($argv[1]) ? $argv[1] : 'google.com';
 $type = constant('React\Dns\Model\Message::TYPE_' . (isset($argv[2]) ? $argv[2] : 'TXT'));

--- a/examples/13-reverse-dns.php
+++ b/examples/13-reverse-dns.php
@@ -9,10 +9,12 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $config = Config::loadSystemConfigBlocking();
-$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+if (!$config->nameservers) {
+    $config->nameservers[] = '8.8.8.8';
+}
 
 $factory = new Factory();
-$resolver = $factory->create($server, $loop);
+$resolver = $factory->create($config, $loop);
 
 $ip = isset($argv[1]) ? $argv[1] : '8.8.8.8';
 


### PR DESCRIPTION
This changeset updates the DNS `Factory` to accept a complete `Config` object instead of only a single DNS nameserver. If the given config contains more than one DNS nameserver, only the primary will be used at the moment. A future version may take advantage of fallback DNS servers (#6).

```php
// old (still supported)
$config = React\Dns\Config\Config::loadSystemConfigBlocking();
$server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
$resolver = $factory->create($server, $loop);

// new
$config = React\Dns\Config\Config::loadSystemConfigBlocking();
if (!$config->nameservers) {
    $config->nameservers[] = '8.8.8.8';
}
$resolver = $factory->create($config, $loop);
```

This is a prerequisite for supporting multiple DNS servers (#6) that will be added in a follow-up PR. Additionally, this can be used as a basis to respect more settings from the DNS config in the future (#158 and #98). This is a pure future addition that works across all supported platforms and does not affect BC.

Supersedes / closes #175