### PR TITLE
Add new `FallbackExecutor` and update DNS `Factory` to use fallback DNS servers when DNS `Config` lists multiple servers

### DIFF
--- a/src/Query/FallbackExecutor.php
+++ b/src/Query/FallbackExecutor.php
@@ -2,6 +2,8 @@
 
 namespace React\Dns\Query;
 
+use React\Promise\Promise;
+
 final class FallbackExecutor implements ExecutorInterface
 {
     private $executor;
@@ -15,16 +17,33 @@ final class FallbackExecutor implements ExecutorInterface
 
     public function query(Query $query)
     {
+        $cancelled = false;
         $fallback = $this->fallback;
-        return $this->executor->query($query)->then(null, function (\Exception $e1) use ($query, $fallback) {
-            return $fallback->query($query)->then(null, function (\Exception $e2) use ($e1) {
-                $append = $e2->getMessage();
-                if (($pos = strpos($append, ':')) !== false) {
-                    $append = substr($append, $pos + 2);
+        $promise = $this->executor->query($query);
+
+        return new Promise(function ($resolve, $reject) use (&$promise, $fallback, $query, &$cancelled) {
+            $promise->then($resolve, function (\Exception $e1) use ($fallback, $query, $resolve, $reject, &$cancelled, &$promise) {
+                // reject if primary resolution rejected due to cancellation
+                if ($cancelled) {
+                    $reject($e1);
+                    return;
                 }
 
-                throw new \RuntimeException($e1->getMessage() . '. ' . $append);
+                // start fallback query if primary query rejected
+                $promise = $fallback->query($query)->then($resolve, function (\Exception $e2) use ($e1, $reject) {
+                    $append = $e2->getMessage();
+                    if (($pos = strpos($append, ':')) !== false) {
+                        $append = substr($append, $pos + 2);
+                    }
+
+                    // reject with combined error message if both queries fail
+                    $reject(new \RuntimeException($e1->getMessage() . '. ' . $append));
+                });
             });
+        }, function () use (&$promise, &$cancelled) {
+            // cancel pending query (primary or fallback)
+            $cancelled = true;
+            $promise->cancel();
         });
     }
 }

--- a/src/Query/FallbackExecutor.php
+++ b/src/Query/FallbackExecutor.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace React\Dns\Query;
+
+final class FallbackExecutor implements ExecutorInterface
+{
+    private $executor;
+    private $fallback;
+
+    public function __construct(ExecutorInterface $executor, ExecutorInterface $fallback)
+    {
+        $this->executor = $executor;
+        $this->fallback = $fallback;
+    }
+
+    public function query(Query $query)
+    {
+        $fallback = $this->fallback;
+        return $this->executor->query($query)->then(null, function (\Exception $e1) use ($query, $fallback) {
+            return $fallback->query($query)->then(null, function (\Exception $e2) use ($e1) {
+                $append = $e2->getMessage();
+                if (($pos = strpos($append, ':')) !== false) {
+                    $append = substr($append, $pos + 2);
+                }
+
+                throw new \RuntimeException($e1->getMessage() . '. ' . $append);
+            });
+        });
+    }
+}

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -9,6 +9,7 @@ use React\Dns\Config\HostsFile;
 use React\Dns\Query\CachingExecutor;
 use React\Dns\Query\CoopExecutor;
 use React\Dns\Query\ExecutorInterface;
+use React\Dns\Query\FallbackExecutor;
 use React\Dns\Query\HostsFileExecutor;
 use React\Dns\Query\RetryExecutor;
 use React\Dns\Query\SelectiveTransportExecutor;
@@ -24,8 +25,9 @@ final class Factory
      *
      * As of v1.7.0 it's recommended to pass a `Config` object instead of a
      * single nameserver address. If the given config contains more than one DNS
-     * nameserver, only the primary will be used at the moment. A future version
-     * may take advantage of fallback DNS servers.
+     * nameserver, all DNS nameservers will be used in order. The primary DNS
+     * server will always be used first before falling back to the secondary DNS
+     * server.
      *
      * @param Config|string $config DNS Config object (recommended) or single nameserver address
      * @param LoopInterface $loop
@@ -45,8 +47,9 @@ final class Factory
      *
      * As of v1.7.0 it's recommended to pass a `Config` object instead of a
      * single nameserver address. If the given config contains more than one DNS
-     * nameserver, only the primary will be used at the moment. A future version
-     * may take advantage of fallback DNS servers.
+     * nameserver, all DNS nameservers will be used in order. The primary DNS
+     * server will always be used first before falling back to the secondary DNS
+     * server.
      *
      * @param Config|string   $config DNS Config object (recommended) or single nameserver address
      * @param LoopInterface   $loop
@@ -109,12 +112,38 @@ final class Factory
     private function createExecutor($nameserver, LoopInterface $loop)
     {
         if ($nameserver instanceof Config) {
-            $nameserver = \reset($nameserver->nameservers);
-            if ($nameserver === false) {
+            if (!$nameserver->nameservers) {
                 throw new \UnderflowException('Empty config with no DNS servers');
+            }
+
+            $primary = reset($nameserver->nameservers);
+            $secondary = next($nameserver->nameservers);
+
+            if ($secondary !== false) {
+                return new CoopExecutor(
+                    new RetryExecutor(
+                        new FallbackExecutor(
+                            $this->createSingleExecutor($primary, $loop),
+                            $this->createSingleExecutor($secondary, $loop)
+                        )
+                    )
+                );
+            } else {
+                $nameserver = $primary;
             }
         }
 
+        return new CoopExecutor(new RetryExecutor($this->createSingleExecutor($nameserver, $loop)));
+    }
+
+    /**
+     * @param string $nameserver
+     * @param LoopInterface $loop
+     * @return ExecutorInterface
+     * @throws \InvalidArgumentException for invalid DNS server address
+     */
+    private function createSingleExecutor($nameserver, LoopInterface $loop)
+    {
         $parts = \parse_url($nameserver);
 
         if (isset($parts['scheme']) && $parts['scheme'] === 'tcp') {
@@ -128,9 +157,15 @@ final class Factory
             );
         }
 
-        return new CoopExecutor(new RetryExecutor($executor));
+        return $executor;
     }
 
+    /**
+     * @param string $nameserver
+     * @param LoopInterface $loop
+     * @return TimeoutExecutor
+     * @throws \InvalidArgumentException for invalid DNS server address
+     */
     private function createTcpExecutor($nameserver, LoopInterface $loop)
     {
         return new TimeoutExecutor(
@@ -140,6 +175,12 @@ final class Factory
         );
     }
 
+    /**
+     * @param string $nameserver
+     * @param LoopInterface $loop
+     * @return TimeoutExecutor
+     * @throws \InvalidArgumentException for invalid DNS server address
+     */
     private function createUdpExecutor($nameserver, LoopInterface $loop)
     {
         return new TimeoutExecutor(

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -128,7 +128,7 @@ final class Factory
             );
         }
 
-        return new CoopExecutor($executor);
+        return new CoopExecutor(new RetryExecutor($executor));
     }
 
     private function createTcpExecutor($nameserver, LoopInterface $loop)
@@ -142,15 +142,13 @@ final class Factory
 
     private function createUdpExecutor($nameserver, LoopInterface $loop)
     {
-        return new RetryExecutor(
-            new TimeoutExecutor(
-                new UdpTransportExecutor(
-                    $nameserver,
-                    $loop
-                ),
-                5.0,
+        return new TimeoutExecutor(
+            new UdpTransportExecutor(
+                $nameserver,
                 $loop
-            )
+            ),
+            5.0,
+            $loop
         );
     }
 }

--- a/tests/Query/FallbackExecutorTest.php
+++ b/tests/Query/FallbackExecutorTest.php
@@ -134,8 +134,6 @@ class FallbackExecutorTest extends TestCase
 
     public function testCancelQueryWillReturnRejectedPromiseWithoutCallingSecondaryExecutorWhenPrimaryExecutorIsStillPending()
     {
-        $this->markTestIncomplete();
-
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
         $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
@@ -151,5 +149,76 @@ class FallbackExecutorTest extends TestCase
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
+
+    public function testCancelQueryWillReturnRejectedPromiseWhenPrimaryExecutorRejectsAndSecondaryExecutorIsStillPending()
+    {
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException()));
+
+        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary->expects($this->once())->method('query')->with($query)->willReturn(new Promise(function () { }, function () { throw new \RuntimeException(); }));
+
+        $executor = new FallbackExecutor($primary, $secondary);
+
+        $promise = $executor->query($query);
+        $promise->cancel();
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
+
+    public function testCancelQueryShouldNotCauseGarbageReferencesWhenCancellingPrimaryExecutor()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary->expects($this->once())->method('query')->willReturn(new Promise(function () { }, function () { throw new \RuntimeException(); }));
+
+        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary->expects($this->never())->method('query');
+
+        $executor = new FallbackExecutor($primary, $secondary);
+
+        gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $promise = $executor->query($query);
+        $promise->cancel();
+        $promise = null;
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testCancelQueryShouldNotCauseGarbageReferencesWhenCancellingSecondaryExecutor()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary->expects($this->once())->method('query')->willReturn(\React\Promise\reject(new \RuntimeException()));
+
+        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary->expects($this->once())->method('query')->willReturn(new Promise(function () { }, function () { throw new \RuntimeException(); }));
+
+        $executor = new FallbackExecutor($primary, $secondary);
+
+        gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $promise = $executor->query($query);
+        $promise->cancel();
+        $promise = null;
+
+        $this->assertEquals(0, gc_collect_cycles());
     }
 }

--- a/tests/Query/FallbackExecutorTest.php
+++ b/tests/Query/FallbackExecutorTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace React\Tests\Dns\Query;
+
+use React\Dns\Model\Message;
+use React\Dns\Query\FallbackExecutor;
+use React\Dns\Query\Query;
+use React\Promise\Promise;
+use React\Tests\Dns\TestCase;
+
+class FallbackExecutorTest extends TestCase
+{
+    public function testQueryWillReturnPendingPromiseWhenPrimaryExecutorIsStillPending()
+    {
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(new Promise(function () { }));
+
+        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+
+        $executor = new FallbackExecutor($primary, $secondary);
+
+        $promise = $executor->query($query);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then($this->expectCallableNever(), $this->expectCallableNever());
+    }
+
+    public function testQueryWillResolveWithMessageWhenPrimaryExecutorResolvesWithMessage()
+    {
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\resolve(new Message()));
+
+        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+
+        $executor = new FallbackExecutor($primary, $secondary);
+
+        $promise = $executor->query($query);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then($this->expectCallableOnceWith($this->isInstanceOf('React\Dns\Model\Message')), $this->expectCallableNever());
+    }
+
+    public function testQueryWillReturnPendingPromiseWhenPrimaryExecutorRejectsPromiseAndSecondaryExecutorIsStillPending()
+    {
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException()));
+
+        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary->expects($this->once())->method('query')->with($query)->willReturn(new Promise(function () { }));
+
+        $executor = new FallbackExecutor($primary, $secondary);
+
+        $promise = $executor->query($query);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then($this->expectCallableNever(), $this->expectCallableNever());
+    }
+
+    public function testQueryWillResolveWithMessageWhenPrimaryExecutorRejectsPromiseAndSecondaryExecutorResolvesWithMessage()
+    {
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException()));
+
+        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\resolve(new Message()));
+
+        $executor = new FallbackExecutor($primary, $secondary);
+
+        $promise = $executor->query($query);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then($this->expectCallableOnceWith($this->isInstanceOf('React\Dns\Model\Message')), $this->expectCallableNever());
+    }
+
+    public function testQueryWillRejectWithExceptionMessagesConcatenatedAfterColonWhenPrimaryExecutorRejectsPromiseAndSecondaryExecutorRejectsPromiseWithMessageWithColon()
+    {
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException('DNS query for reactphp.org (A) failed: Unable to connect to DNS server A')));
+
+        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException('DNS query for reactphp.org (A) failed: Unable to connect to DNS server B')));
+
+        $executor = new FallbackExecutor($primary, $secondary);
+
+        $promise = $executor->query($query);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce($this->isInstanceOf('Exception')));
+
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertEquals('DNS query for reactphp.org (A) failed: Unable to connect to DNS server A. Unable to connect to DNS server B', $exception->getMessage());
+    }
+
+    public function testQueryWillRejectWithExceptionMessagesConcatenatedInFullWhenPrimaryExecutorRejectsPromiseAndSecondaryExecutorRejectsPromiseWithMessageWithNoColon()
+    {
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException('Reason A')));
+
+        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException('Reason B')));
+
+        $executor = new FallbackExecutor($primary, $secondary);
+
+        $promise = $executor->query($query);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce($this->isInstanceOf('Exception')));
+
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertEquals('Reason A. Reason B', $exception->getMessage());
+    }
+
+    public function testCancelQueryWillReturnRejectedPromiseWithoutCallingSecondaryExecutorWhenPrimaryExecutorIsStillPending()
+    {
+        $this->markTestIncomplete();
+
+        $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
+
+        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(new Promise(function () { }, function () { throw new \RuntimeException(); }));
+
+        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary->expects($this->never())->method('query');
+
+        $executor = new FallbackExecutor($primary, $secondary);
+
+        $promise = $executor->query($query);
+        $promise->cancel();
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
+}

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -36,7 +36,13 @@ class FactoryTest extends TestCase
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
         $ref->setAccessible(true);
-        $selectiveExecutor = $ref->getValue($coopExecutor);
+        $retryExecutor = $ref->getValue($coopExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
+
+        $ref = new \ReflectionProperty($retryExecutor, 'executor');
+        $ref->setAccessible(true);
+        $selectiveExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\SelectiveTransportExecutor', $selectiveExecutor);
 
@@ -44,13 +50,7 @@ class FactoryTest extends TestCase
 
         $ref = new \ReflectionProperty($selectiveExecutor, 'datagramExecutor');
         $ref->setAccessible(true);
-        $retryExecutor = $ref->getValue($selectiveExecutor);
-
-        $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
-
-        $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
-        $timeoutExecutor = $ref->getValue($retryExecutor);
+        $timeoutExecutor = $ref->getValue($selectiveExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
@@ -124,7 +124,13 @@ class FactoryTest extends TestCase
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
         $ref->setAccessible(true);
-        $timeoutExecutor = $ref->getValue($coopExecutor);
+        $retryExecutor = $ref->getValue($coopExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
+
+        $ref = new \ReflectionProperty($retryExecutor, 'executor');
+        $ref->setAccessible(true);
+        $timeoutExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
@@ -154,7 +160,13 @@ class FactoryTest extends TestCase
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
         $ref->setAccessible(true);
-        $timeoutExecutor = $ref->getValue($coopExecutor);
+        $retryExecutor = $ref->getValue($coopExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
+
+        $ref = new \ReflectionProperty($retryExecutor, 'executor');
+        $ref->setAccessible(true);
+        $timeoutExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -178,7 +178,7 @@ class FactoryTest extends TestCase
     }
 
     /** @test */
-    public function createWithConfigWithMultipleWithTcpSchemeShouldCreateResolverWithTcpExecutorStack()
+    public function createWithConfigWithTwoNameserversWithTcpSchemeShouldCreateResolverWithFallbackExecutorStack()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -242,6 +242,98 @@ class FactoryTest extends TestCase
         $nameserver = $ref->getValue($tcpExecutor);
 
         $this->assertEquals('tcp://1.1.1.1:53', $nameserver);
+    }
+
+    /** @test */
+    public function createWithConfigWithThreeNameserversWithTcpSchemeShouldCreateResolverWithNestedFallbackExecutorStack()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $config = new Config();
+        $config->nameservers[] = 'tcp://8.8.8.8:53';
+        $config->nameservers[] = 'tcp://1.1.1.1:53';
+        $config->nameservers[] = 'tcp://9.9.9.9:53';
+
+        $factory = new Factory();
+        $resolver = $factory->create($config, $loop);
+
+        $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
+
+        $coopExecutor = $this->getResolverPrivateExecutor($resolver);
+
+        $this->assertInstanceOf('React\Dns\Query\CoopExecutor', $coopExecutor);
+
+        $ref = new \ReflectionProperty($coopExecutor, 'executor');
+        $ref->setAccessible(true);
+        $retryExecutor = $ref->getValue($coopExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
+
+        $ref = new \ReflectionProperty($retryExecutor, 'executor');
+        $ref->setAccessible(true);
+        $fallbackExecutor = $ref->getValue($retryExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\FallbackExecutor', $fallbackExecutor);
+
+        $ref = new \ReflectionProperty($fallbackExecutor, 'executor');
+        $ref->setAccessible(true);
+        $timeoutExecutor = $ref->getValue($fallbackExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
+
+        $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
+        $ref->setAccessible(true);
+        $tcpExecutor = $ref->getValue($timeoutExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
+
+        $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
+        $ref->setAccessible(true);
+        $nameserver = $ref->getValue($tcpExecutor);
+
+        $this->assertEquals('tcp://8.8.8.8:53', $nameserver);
+
+        $ref = new \ReflectionProperty($fallbackExecutor, 'fallback');
+        $ref->setAccessible(true);
+        $fallbackExecutor = $ref->getValue($fallbackExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\FallbackExecutor', $fallbackExecutor);
+
+        $ref = new \ReflectionProperty($fallbackExecutor, 'executor');
+        $ref->setAccessible(true);
+        $timeoutExecutor = $ref->getValue($fallbackExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
+
+        $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
+        $ref->setAccessible(true);
+        $tcpExecutor = $ref->getValue($timeoutExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
+
+        $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
+        $ref->setAccessible(true);
+        $nameserver = $ref->getValue($tcpExecutor);
+
+        $this->assertEquals('tcp://1.1.1.1:53', $nameserver);
+
+        $ref = new \ReflectionProperty($fallbackExecutor, 'fallback');
+        $ref->setAccessible(true);
+        $timeoutExecutor = $ref->getValue($fallbackExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
+
+        $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
+        $ref->setAccessible(true);
+        $tcpExecutor = $ref->getValue($timeoutExecutor);
+
+        $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
+
+        $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
+        $ref->setAccessible(true);
+        $nameserver = $ref->getValue($tcpExecutor);
+
+        $this->assertEquals('tcp://9.9.9.9:53', $nameserver);
     }
 
     /** @test */


### PR DESCRIPTION
This changeset adds a new `FallbackExecutor` and subsequently updates the DNS `Factory` to use fallback DNS servers when DNS `Config` lists multiple servers.

Previous versions would only use the first DNS server listed in the DNS `Config`. With these changes applied, it will take up to three DNS servers from this list. This is artificially limited to match default limits in place in most systems (see `MAXNS` config). Internally, it will implement the same strategy that is used in most systems: Always query the first DNS server and if this fails (or times out), use the second DNS server and so on. See also `man resolv.conf` for details.

Most systems (*citation needed*) use only a single DNS server and would not be affected by this change. A reasonable number of systems (*citation needed*) use multiple DNS servers as a fallback just in case and have a functioning primary DNS server and would not be affected by this change. A very small number of systems would use multiple DNS servers and have broken connectivity with their primary DNS server, these systems can now resolve DNS queries, albeit with a noticeable delay.

Accordingly, this is a pure future addition that works across all supported platforms and does not affect BC.

Builds on  top of #179 
Resolves / closes #6 
Supersedes / closes #131 