### PR TITLE
only return valid IPs

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -85,7 +85,7 @@ final class Config
         preg_match_all('/^nameserver\s+(\S+)\s*$/m', $contents, $matches);
 
         $config = new self();
-        $config->nameservers = [];
+        $config->nameservers = array();
 
         /* only valid IP */
         foreach($matches[1] as $n) {

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -85,7 +85,14 @@ final class Config
         preg_match_all('/^nameserver\s+(\S+)\s*$/m', $contents, $matches);
 
         $config = new self();
-        $config->nameservers = $matches[1];
+        $config->nameservers = [];
+
+        /* only valid IP */
+        foreach($matches[1] as $n) {
+            if (filter_var("$n",FILTER_VALIDATE_IP)) {
+                $config->nameservers[] = $n;
+            }
+        }
 
         return $config;
     }


### PR DESCRIPTION
On recent linux distro (e.g. Fedora 33+) Network Manager generates /etc/Resolv.conf with interface references

Example:

```
# Generated by NetworkManager
search remirepo.net
nameserver 192.168.1.1
nameserver fe80::7e94:2aff:fe85:5cce%eno1
```

Last address is not valid, but not filtered by loadResolvConfBlocking, so create unusable configuration
Ex: running react/socket test suite

```
There were 8 errors:

1) React\Tests\Socket\ConnectorTest::testConnectorUsesTcpAsDefaultScheme
InvalidArgumentException: Invalid nameserver address given

/usr/share/php/React/Dns/Query/UdpTransportExecutor.php:115
...
```

This trivial fix filter to only return valid IPs