### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,17 @@ factory. All you need to give it is a nameserver, then you can start resolving
 names, baby!
 
 ```php
-$loop = React\EventLoop\Factory::create();
-
 $config = React\Dns\Config\Config::loadSystemConfigBlocking();
 if (!$config->nameservers) {
     $config->nameservers[] = '8.8.8.8';
 }
 
 $factory = new React\Dns\Resolver\Factory();
-$dns = $factory->create($config, $loop);
+$dns = $factory->create($config);
 
 $dns->resolve('igor.io')->then(function ($ip) {
     echo "Host: $ip\n";
 });
-
-$loop->run();
 ```
 
 See also the [first example](examples).
@@ -72,15 +68,13 @@ But there's more.
 You can cache results by configuring the resolver to use a `CachedExecutor`:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-
 $config = React\Dns\Config\Config::loadSystemConfigBlocking();
 if (!$config->nameservers) {
     $config->nameservers[] = '8.8.8.8';
 }
 
 $factory = new React\Dns\Resolver\Factory();
-$dns = $factory->createCached($config, $loop);
+$dns = $factory->createCached($config);
 
 $dns->resolve('igor.io')->then(function ($ip) {
     echo "Host: $ip\n";
@@ -91,8 +85,6 @@ $dns->resolve('igor.io')->then(function ($ip) {
 $dns->resolve('igor.io')->then(function ($ip) {
     echo "Host: $ip\n";
 });
-
-$loop->run();
 ```
 
 If the first call returns before the second, only one query will be executed.
@@ -110,9 +102,8 @@ You can also specify a custom cache implementing [`CacheInterface`](https://gith
 
 ```php
 $cache = new React\Cache\ArrayCache();
-$loop = React\EventLoop\Factory::create();
 $factory = new React\Dns\Resolver\Factory();
-$dns = $factory->createCached('8.8.8.8', $loop, $cache);
+$dns = $factory->createCached('8.8.8.8', null, $cache);
 ```
 
 See also the wiki for possible [cache implementations](https://github.com/reactphp/react/wiki/Users#cache-implementations).
@@ -215,8 +206,7 @@ For more advanced usages one can utilize this class directly.
 The following example looks up the `IPv6` address for `igor.io`.
 
 ```php
-$loop = Factory::create();
-$executor = new UdpTransportExecutor('8.8.8.8:53', $loop);
+$executor = new UdpTransportExecutor('8.8.8.8:53');
 
 $executor->query(
     new Query($name, Message::TYPE_AAAA, Message::CLASS_IN)
@@ -225,8 +215,6 @@ $executor->query(
         echo 'IPv6: ' . $answer->data . PHP_EOL;
     }
 }, 'printf');
-
-$loop->run();
 ```
 
 See also the [fourth example](examples).
@@ -236,9 +224,8 @@ want to use this in combination with a `TimeoutExecutor` like this:
 
 ```php
 $executor = new TimeoutExecutor(
-    new UdpTransportExecutor($nameserver, $loop),
-    3.0,
-    $loop
+    new UdpTransportExecutor($nameserver),
+    3.0
 );
 ```
 
@@ -249,9 +236,8 @@ combination with a `RetryExecutor` like this:
 ```php
 $executor = new RetryExecutor(
     new TimeoutExecutor(
-        new UdpTransportExecutor($nameserver, $loop),
-        3.0,
-        $loop
+        new UdpTransportExecutor($nameserver),
+        3.0
     )
 );
 ```
@@ -268,9 +254,8 @@ a `CoopExecutor` like this:
 $executor = new CoopExecutor(
     new RetryExecutor(
         new TimeoutExecutor(
-            new UdpTransportExecutor($nameserver, $loop),
-            3.0,
-            $loop
+            new UdpTransportExecutor($nameserver),
+            3.0
         )
     )
 );
@@ -293,8 +278,7 @@ For more advanced usages one can utilize this class directly.
 The following example looks up the `IPv6` address for `reactphp.org`.
 
 ```php
-$loop = Factory::create();
-$executor = new TcpTransportExecutor('8.8.8.8:53', $loop);
+$executor = new TcpTransportExecutor('8.8.8.8:53');
 
 $executor->query(
     new Query($name, Message::TYPE_AAAA, Message::CLASS_IN)
@@ -303,8 +287,6 @@ $executor->query(
         echo 'IPv6: ' . $answer->data . PHP_EOL;
     }
 }, 'printf');
-
-$loop->run();
 ```
 
 See also [example #92](examples).
@@ -314,9 +296,8 @@ want to use this in combination with a `TimeoutExecutor` like this:
 
 ```php
 $executor = new TimeoutExecutor(
-    new TcpTransportExecutor($nameserver, $loop),
-    3.0,
-    $loop
+    new TcpTransportExecutor($nameserver),
+    3.0
 );
 ```
 
@@ -342,9 +323,8 @@ combination with a `CoopExecutor` like this:
 ```php
 $executor = new CoopExecutor(
     new TimeoutExecutor(
-        new TcpTransportExecutor($nameserver, $loop),
-        3.0,
-        $loop
+        new TcpTransportExecutor($nameserver),
+        3.0
     )
 );
 ```
@@ -412,7 +392,7 @@ use this code:
 ```php
 $hosts = \React\Dns\Config\HostsFile::loadFromPathBlocking();
 
-$executor = new UdpTransportExecutor('8.8.8.8:53', $loop);
+$executor = new UdpTransportExecutor('8.8.8.8:53');
 $executor = new HostsFileExecutor($hosts, $executor);
 
 $executor->query(

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=5.3.0",
         "react/cache": "^1.0 || ^0.6 || ^0.5",
-        "react/event-loop": "dev-master#78f7f43 as 1.2.0",
+        "react/event-loop": "^1.2",
         "react/promise": "^3.0 || ^2.7 || ^1.2.1",
         "react/promise-timer": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=5.3.0",
         "react/cache": "^1.0 || ^0.6 || ^0.5",
-        "react/event-loop": "^1.0 || ^0.5",
+        "react/event-loop": "dev-master#78f7f43 as 1.2.0",
         "react/promise": "^3.0 || ^2.7 || ^1.2.1",
         "react/promise-timer": "^1.2"
     },

--- a/examples/01-one.php
+++ b/examples/01-one.php
@@ -5,20 +5,16 @@ use React\Dns\Resolver\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-
 $config = Config::loadSystemConfigBlocking();
 if (!$config->nameservers) {
     $config->nameservers[] = '8.8.8.8';
 }
 
 $factory = new Factory();
-$resolver = $factory->create($config, $loop);
+$resolver = $factory->create($config);
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 
 $resolver->resolve($name)->then(function ($ip) use ($name) {
     echo 'IP for ' . $name . ': ' . $ip . PHP_EOL;
 }, 'printf');
-
-$loop->run();

--- a/examples/02-concurrent.php
+++ b/examples/02-concurrent.php
@@ -5,15 +5,13 @@ use React\Dns\Resolver\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-
 $config = Config::loadSystemConfigBlocking();
 if (!$config->nameservers) {
     $config->nameservers[] = '8.8.8.8';
 }
 
 $factory = new Factory();
-$resolver = $factory->create($config, $loop);
+$resolver = $factory->create($config);
 
 $names = array_slice($argv, 1);
 if (!$names) {
@@ -25,5 +23,3 @@ foreach ($names as $name) {
         echo 'IP for ' . $name . ': ' . $ip . PHP_EOL;
     }, 'printf');
 }
-
-$loop->run();

--- a/examples/03-cached.php
+++ b/examples/03-cached.php
@@ -2,10 +2,9 @@
 
 use React\Dns\Config\Config;
 use React\Dns\Resolver\Factory;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
-
-$loop = React\EventLoop\Factory::create();
 
 $config = Config::loadSystemConfigBlocking();
 if (!$config->nameservers) {
@@ -13,7 +12,7 @@ if (!$config->nameservers) {
 }
 
 $factory = new Factory();
-$resolver = $factory->createCached($config, $loop);
+$resolver = $factory->createCached($config);
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 
@@ -21,22 +20,20 @@ $resolver->resolve($name)->then(function ($ip) use ($name) {
     echo 'IP for ' . $name . ': ' . $ip . PHP_EOL;
 }, 'printf');
 
-$loop->addTimer(1.0, function() use ($name, $resolver) {
+Loop::addTimer(1.0, function() use ($name, $resolver) {
     $resolver->resolve($name)->then(function ($ip) use ($name) {
         echo 'IP for ' . $name . ': ' . $ip . PHP_EOL;
     }, 'printf');
 });
 
-$loop->addTimer(2.0, function() use ($name, $resolver) {
+Loop::addTimer(2.0, function() use ($name, $resolver) {
     $resolver->resolve($name)->then(function ($ip) use ($name) {
         echo 'IP for ' . $name . ': ' . $ip . PHP_EOL;
     }, 'printf');
 });
 
-$loop->addTimer(3.0, function() use ($name, $resolver) {
+Loop::addTimer(3.0, function() use ($name, $resolver) {
     $resolver->resolve($name)->then(function ($ip) use ($name) {
         echo 'IP for ' . $name . ': ' . $ip . PHP_EOL;
     }, 'printf');
 });
-
-$loop->run();

--- a/examples/11-all-ips.php
+++ b/examples/11-all-ips.php
@@ -6,15 +6,13 @@ use React\Dns\Model\Message;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-
 $config = Config::loadSystemConfigBlocking();
 if (!$config->nameservers) {
     $config->nameservers[] = '8.8.8.8';
 }
 
 $factory = new Factory();
-$resolver = $factory->create($config, $loop);
+$resolver = $factory->create($config);
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 
@@ -29,5 +27,3 @@ $resolver->resolveAll($name, Message::TYPE_AAAA)->then(function (array $ips) use
 }, function (Exception $e) use ($name) {
     echo 'No IPv6 addresses for ' . $name . ': ' . $e->getMessage() . PHP_EOL;
 });
-
-$loop->run();

--- a/examples/12-all-types.php
+++ b/examples/12-all-types.php
@@ -8,15 +8,13 @@ use React\Dns\Resolver\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-
 $config = Config::loadSystemConfigBlocking();
 if (!$config->nameservers) {
     $config->nameservers[] = '8.8.8.8';
 }
 
 $factory = new Factory();
-$resolver = $factory->create($config, $loop);
+$resolver = $factory->create($config);
 
 $name = isset($argv[1]) ? $argv[1] : 'google.com';
 $type = constant('React\Dns\Model\Message::TYPE_' . (isset($argv[2]) ? $argv[2] : 'TXT'));
@@ -26,5 +24,3 @@ $resolver->resolveAll($name, $type)->then(function (array $values) {
 }, function (Exception $e) {
     echo $e->getMessage() . PHP_EOL;
 });
-
-$loop->run();

--- a/examples/13-reverse-dns.php
+++ b/examples/13-reverse-dns.php
@@ -6,15 +6,13 @@ use React\Dns\Model\Message;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-
 $config = Config::loadSystemConfigBlocking();
 if (!$config->nameservers) {
     $config->nameservers[] = '8.8.8.8';
 }
 
 $factory = new Factory();
-$resolver = $factory->create($config, $loop);
+$resolver = $factory->create($config);
 
 $ip = isset($argv[1]) ? $argv[1] : '8.8.8.8';
 
@@ -33,5 +31,3 @@ $resolver->resolveAll($name, Message::TYPE_PTR)->then(function (array $names) {
 }, function (Exception $e) {
     echo $e->getMessage() . PHP_EOL;
 });
-
-$loop->run();

--- a/examples/91-query-a-and-aaaa.php
+++ b/examples/91-query-a-and-aaaa.php
@@ -7,8 +7,7 @@ use React\EventLoop\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-$executor = new UdpTransportExecutor('8.8.8.8:53', $loop);
+$executor = new UdpTransportExecutor('8.8.8.8:53');
 
 $name = isset($argv[1]) ? $argv[1] : 'www.google.com';
 
@@ -25,5 +24,3 @@ $executor->query($ipv6Query)->then(function (Message $message) {
         echo 'IPv6: ' . $answer->data . PHP_EOL;
     }
 }, 'printf');
-
-$loop->run();

--- a/examples/92-query-any.php
+++ b/examples/92-query-any.php
@@ -11,8 +11,7 @@ use React\EventLoop\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-$executor = new TcpTransportExecutor('8.8.8.8:53', $loop);
+$executor = new TcpTransportExecutor('8.8.8.8:53');
 
 $name = isset($argv[1]) ? $argv[1] : 'google.com';
 
@@ -80,5 +79,3 @@ $executor->query($any)->then(function (Message $message) {
         echo $type . ': ' . $data . PHP_EOL;
     }
 }, 'printf');
-
-$loop->run();

--- a/src/Query/CoopExecutor.php
+++ b/src/Query/CoopExecutor.php
@@ -27,9 +27,8 @@ use React\Promise\Promise;
  * $executor = new CoopExecutor(
  *     new RetryExecutor(
  *         new TimeoutExecutor(
- *             new UdpTransportExecutor($nameserver, $loop),
- *             3.0,
- *             $loop
+ *             new UdpTransportExecutor($nameserver),
+ *             3.0
  *         )
  *     )
  * );

--- a/src/Query/TimeoutExecutor.php
+++ b/src/Query/TimeoutExecutor.php
@@ -2,6 +2,7 @@
 
 namespace React\Dns\Query;
 
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Timer;
 
@@ -11,10 +12,10 @@ final class TimeoutExecutor implements ExecutorInterface
     private $loop;
     private $timeout;
 
-    public function __construct(ExecutorInterface $executor, $timeout, LoopInterface $loop)
+    public function __construct(ExecutorInterface $executor, $timeout, LoopInterface $loop = null)
     {
         $this->executor = $executor;
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
         $this->timeout = $timeout;
     }
 

--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -60,6 +60,17 @@ class TcpTransportExecutorTest extends TestCase
         );
     }
 
+    public function testCtorWithoutLoopShouldAssignDefaultLoop()
+    {
+        $executor = new TcpTransportExecutor('127.0.0.1');
+
+        $ref = new \ReflectionProperty($executor, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($executor);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testCtorShouldThrowWhenNameserverAddressIsInvalid()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();

--- a/tests/Query/TimeoutExecutorTest.php
+++ b/tests/Query/TimeoutExecutorTest.php
@@ -14,6 +14,10 @@ use React\Tests\Dns\TestCase;
 
 class TimeoutExecutorTest extends TestCase
 {
+    private $loop;
+    private $wrapped;
+    private $executor;
+
     /**
      * @before
      */
@@ -24,6 +28,17 @@ class TimeoutExecutorTest extends TestCase
         $this->wrapped = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
 
         $this->executor = new TimeoutExecutor($this->wrapped, 5.0, $this->loop);
+    }
+
+    public function testCtorWithoutLoopShouldAssignDefaultLoop()
+    {
+        $executor = new TimeoutExecutor($this->executor, 5.0);
+
+        $ref = new \ReflectionProperty($executor, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($executor);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
     }
 
     public function testCancellingPromiseWillCancelWrapped()

--- a/tests/Query/UdpTransportExecutorTest.php
+++ b/tests/Query/UdpTransportExecutorTest.php
@@ -60,6 +60,17 @@ class UdpTransportExecutorTest extends TestCase
         );
     }
 
+    public function testCtorWithoutLoopShouldAssignDefaultLoop()
+    {
+        $executor = new UdpTransportExecutor('127.0.0.1');
+
+        $ref = new \ReflectionProperty($executor, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($executor);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testCtorShouldThrowWhenNameserverAddressIsInvalid()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -12,10 +12,8 @@ class FactoryTest extends TestCase
     /** @test */
     public function createShouldCreateResolver()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-
         $factory = new Factory();
-        $resolver = $factory->create('8.8.8.8:53', $loop);
+        $resolver = $factory->create('8.8.8.8:53');
 
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
     }
@@ -375,10 +373,8 @@ class FactoryTest extends TestCase
     /** @test */
     public function createCachedShouldCreateResolverWithCachingExecutor()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-
         $factory = new Factory();
-        $resolver = $factory->createCached('8.8.8.8:53', $loop);
+        $resolver = $factory->createCached('8.8.8.8:53');
 
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
         $executor = $this->getResolverPrivateExecutor($resolver);


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$factory = new React\Dns\Resolver\Factory();
$resolver = $factory->create($config, $loop);

// new (using default loop)
$factory = new React\Dns\Resolver\Factory();
$resolver = $factory->create($config);
```

Builds on top of https://github.com/reactphp/event-loop/pull/226, https://github.com/reactphp/event-loop/pull/229 and https://github.com/reactphp/event-loop/pull/232
Refs https://github.com/reactphp/stream/pull/159