### PR TITLE
Avoid dependency on `ext-filter`

### DIFF
--- a/src/Query/TcpTransportExecutor.php
+++ b/src/Query/TcpTransportExecutor.php
@@ -139,7 +139,7 @@ class TcpTransportExecutor implements ExecutorInterface
         }
 
         $parts = \parse_url((\strpos($nameserver, '://') === false ? 'tcp://' : '') . $nameserver);
-        if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'tcp' || !\filter_var(\trim($parts['host'], '[]'), \FILTER_VALIDATE_IP)) {
+        if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'tcp' || @\inet_pton(\trim($parts['host'], '[]')) === false) {
             throw new \InvalidArgumentException('Invalid nameserver address given');
         }
 

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -106,7 +106,7 @@ final class UdpTransportExecutor implements ExecutorInterface
         }
 
         $parts = \parse_url((\strpos($nameserver, '://') === false ? 'udp://' : '') . $nameserver);
-        if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'udp' || !\filter_var(\trim($parts['host'], '[]'), \FILTER_VALIDATE_IP)) {
+        if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'udp' || @\inet_pton(\trim($parts['host'], '[]')) === false) {
             throw new \InvalidArgumentException('Invalid nameserver address given');
         }
 


### PR DESCRIPTION
This simple changeset avoids an unneeded (and undeclared!) dependency on `ext-filter`. The extension is enabled by default, but can explicitly be disabled with `--without-filter`.

The code in question is already covered by the test suite, so the test suite confirms this changeset does not affect behavior or our public API in any way. Accordingly, this is entirely transparent for all consumers of this package, plus now also supports consumers that happen use `--without-filter`.

See https://www.php.net/manual/en/filter.installation.php
Originally reported in https://github.com/leproxy/leproxy/issues/80
Refs https://github.com/reactphp/socket/pull/17