### PR TITLE
Skip invalid nameserver entries from `resolv.conf` and ignore IPv6 zone IDs

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -82,10 +82,20 @@ final class Config
             throw new RuntimeException('Unable to load resolv.conf file "' . $path . '"');
         }
 
+        $matches = array();
         preg_match_all('/^nameserver\s+(\S+)\s*$/m', $contents, $matches);
 
         $config = new self();
-        $config->nameservers = $matches[1];
+        foreach ($matches[1] as $ip) {
+            // remove IPv6 zone ID (`fe80::1%lo0` => `fe80:1`)
+            if (strpos($ip, ':') !== false && ($pos = strpos($ip, '%')) !== false) {
+                $ip = substr($ip, 0, $pos);
+            }
+
+            if (@inet_pton($ip) !== false) {
+                $config->nameservers[] = $ip;
+            }
+        }
 
         return $config;
     }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -47,6 +47,15 @@ class ConfigTest extends TestCase
         $this->assertEquals($expected, $config->nameservers);
     }
 
+    public function testParsesNameserverWithoutIpv6ScopeId()
+    {
+        $contents = 'nameserver ::1%lo';
+        $expected = array('::1');
+
+        $config = Config::loadResolvConfBlocking('data://text/plain;base64,' . base64_encode($contents));
+        $this->assertEquals($expected, $config->nameservers);
+    }
+
     public function testParsesNameserverEntriesFromAverageFileCorrectly()
     {
         $contents = '#
@@ -70,7 +79,6 @@ nameserver ::1
 
     public function testParsesEmptyFileWithoutNameserverEntries()
     {
-        $contents = '';
         $expected = array();
 
         $config = Config::loadResolvConfBlocking('data://text/plain;base64,');
@@ -87,6 +95,7 @@ nameserver 3.4.5.6 # nope
 nameserver 4.5.6.7 5.6.7.8
   nameserver 6.7.8.9
 NameServer 7.8.9.10
+nameserver localhost
 ';
         $expected = array();
 


### PR DESCRIPTION
This changeset improves parsing of the `/etc/resolv.conf` file by skipping invalid nameserver entries and also ignoring any IPv6 zone IDs (scope IDs). This is now more in line with how glibc also completely ignores invalid entries and also only provides somewhat limited support for IPv6 zone IDs.

Prior to these changes, having a completely valid `/etc/resolv.conf` with a `nameserver ::0%lo0` entry would throw an `InvalidArgumentException` because both the `UdpTransportExecutor` and `TcpTransportExecutor` consider this to be an invalid IP address. To make matters worse, this also happens if this is only a secondary DNS server address that's not even in active use, so it will not even try to primary DNS server in this case.

After applying these changes, it will now use `::0` (without the zone ID / scope ID). This isn't exactly perfect, but it's a major improvement over the previous situation. Altogether, this is a rather rare situation and using routable IPv6 is usually preferable.

If you're curious, PHP provides only very limited support for IPv6 addresses with scope IDs. Once this situation improves, we could potentially add full support for scope IDs.

* https://github.com/php/php-src/search?q=sin6_scope_id
* https://man7.org/linux/man-pages/man7/ipv6.7.html
* https://unix.stackexchange.com/questions/174767/ipv6-zone-id-in-etc-hosts
* https://bugs.php.net/bug.php?id=65808

Supersedes / closes #181 (thanks @remicollet for the original suggestion!)
Refs #75 and #76 for similar logic when parsing `/etc/hosts`