### PR TITLE
Support PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "react/cache": "^1.0 || ^0.6 || ^0.5",
         "react/event-loop": "^1.2",
         "react/promise": "^3.0 || ^2.7 || ^1.2.1",
-        "react/promise-timer": "^1.2"
+        "react/promise-timer": "^1.8"
     },
     "require-dev": {
         "clue/block-react": "^1.2",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         cacheResult="false"
          colors="true"
-         cacheResult="false">
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="React Test Suite">
             <directory>./tests/</directory>

--- a/src/Config/HostsFile.php
+++ b/src/Config/HostsFile.php
@@ -133,8 +133,8 @@ class HostsFile
 
         $names = array();
         foreach (preg_split('/\r?\n/', $this->contents) as $line) {
-            $parts = preg_split('/\s+/', $line, null, PREG_SPLIT_NO_EMPTY);
-            $addr = array_shift($parts);
+            $parts = preg_split('/\s+/', $line, -1, PREG_SPLIT_NO_EMPTY);
+            $addr = (string) array_shift($parts);
 
             // remove IPv6 zone ID (`fe80::1%lo0` => `fe80:1`)
             if (strpos($addr, ':') !== false && ($pos = strpos($addr, '%')) !== false) {

--- a/src/Protocol/BinaryDumper.php
+++ b/src/Protocol/BinaryDumper.php
@@ -146,7 +146,7 @@ final class BinaryDumper
                         if ($opt === Message::OPT_TCP_KEEPALIVE && $value !== null) {
                             $value = \pack('n', round($value * 10));
                         }
-                        $binary .= \pack('n*', $opt, \strlen($value)) . $value;
+                        $binary .= \pack('n*', $opt, \strlen((string) $value)) . $value;
                     }
                     break;
                 default:


### PR DESCRIPTION
This changeset adds support for PHP 8.1.

~~I'm marking this as WIP because it currently reports a deprecation notice that needs to be addressed upstream first (https://github.com/reactphp/promise-timer/pull/50). I'll update this PR once this version is released.~~

Builds on top of #184
Refs https://github.com/friends-of-reactphp/mysql/pull/150