### PR TITLE
Reduce socket read chunk size for queries over TCP/IP

### DIFF
--- a/src/Query/TcpTransportExecutor.php
+++ b/src/Query/TcpTransportExecutor.php
@@ -127,6 +127,9 @@ class TcpTransportExecutor implements ExecutorInterface
     private $readBuffer = '';
     private $readPending = false;
 
+    /** @var string */
+    private $readChunk = 0xffff;
+
     /**
      * @param string         $nameserver
      * @param ?LoopInterface $loop
@@ -181,7 +184,7 @@ class TcpTransportExecutor implements ExecutorInterface
             // set socket to non-blocking and wait for it to become writable (connection success/rejected)
             \stream_set_blocking($socket, false);
             if (\function_exists('stream_set_chunk_size')) {
-                \stream_set_chunk_size($socket, (int) ((1 << 31) - 1)); // @codeCoverageIgnore
+                \stream_set_chunk_size($socket, $this->readChunk); // @codeCoverageIgnore
             }
             $this->socket = $socket;
         }
@@ -270,7 +273,7 @@ class TcpTransportExecutor implements ExecutorInterface
     {
         // read one chunk of data from the DNS server
         // any error is fatal, this is a stream of TCP/IP data
-        $chunk = @\fread($this->socket, 65536);
+        $chunk = @\fread($this->socket, $this->readChunk);
         if ($chunk === false || $chunk === '') {
             $this->closeError('Connection to DNS server ' . $this->nameserver . ' lost');
             return;


### PR DESCRIPTION
This changeset reduces the socket read chunk size for queries over TCP/IP to a reasonable value of 64 KiB. PHP's `fread()` uses an underlying `read()` call with the given chunk size (defaults to 8 KiB) instead of the size limit given to the `fread()` call. In an attempt to address a race condition on Mac, I've accidentally raised this default chunk size to 2 GiB via #172/#177. This means that any socket read would temporarily consume 2 GiB of memory, even if we only read a few bytes of data. Ouch.

With these changes applied, the test suite now reports a memory usage of ~84 MB instead of 8 GB(!). I've only stumbled upon this recently while addressing PHP 8.1 compatibility (#188) and trying to execute this with PHP's default `memory_limit` of just 128 MiB. The good news is this didn't usually happen during normal operation, as the TCP/IP transport will only be used as a fallback if the UDP query returns a truncated message.