### PR TITLE
Fix invalid references in exception stack trace

### DIFF
--- a/src/Query/RetryExecutor.php
+++ b/src/Query/RetryExecutor.php
@@ -56,11 +56,11 @@ final class RetryExecutor implements ExecutorInterface
 
                 // Exception trace arguments are not available on some PHP 7.4 installs
                 // @codeCoverageIgnoreStart
-                foreach ($trace as &$one) {
+                foreach ($trace as $ti => $one) {
                     if (isset($one['args'])) {
-                        foreach ($one['args'] as &$arg) {
+                        foreach ($one['args'] as $ai => $arg) {
                             if ($arg instanceof \Closure) {
-                                $arg = 'Object(' . \get_class($arg) . ')';
+                                $trace[$ti]['args'][$ai] = 'Object(' . \get_class($arg) . ')';
                             }
                         }
                     }

--- a/tests/Query/RetryExecutorTest.php
+++ b/tests/Query/RetryExecutorTest.php
@@ -94,9 +94,12 @@ class RetryExecutorTest extends TestCase
             $exception = $reason;
         });
 
-        /** @var \RuntimeException $exception */
+        assert($exception instanceof \RuntimeException);
         $this->assertInstanceOf('RuntimeException', $exception);
         $this->assertEquals('DNS query for igor.io (A) failed: too many retries', $exception->getMessage());
+        $this->assertEquals(0, $exception->getCode());
+        $this->assertInstanceOf('React\Dns\Query\TimeoutException', $exception->getPrevious());
+        $this->assertNotEquals('', $exception->getTraceAsString());
     }
 
     /**


### PR DESCRIPTION
This changeset fixes any invalid references in the exception stack trace. This is a pretty nasty bug that has been introduced a while ago with #118 that only happens on PHP 7+ when printing the exception trace (`$exception->getTraceAsString()`). This is now covered by the updated test suite and should work across all supported PHP versions.

Builds on top of https://github.com/clue/reactphp-socks/pull/104, https://github.com/reactphp/socket/pull/284, and #118