### PR TITLE
Add badge to show number of project installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DNS
 
 [![CI status](https://github.com/reactphp/dns/workflows/CI/badge.svg)](https://github.com/reactphp/dns/actions)
+[![installs on Packagist](https://img.shields.io/packagist/dt/react/dns?color=blue&label=installs%20on%20Packagist)](https://packagist.org/packages/react/dns)
 
 Async DNS resolver for [ReactPHP](https://reactphp.org/).
 


### PR DESCRIPTION
This PR adds a badge with the number of installation on packagist to the README.

Builds on top of https://github.com/reactphp/socket/pull/285.