### PR TITLE
Make tests compatible with PHP 8.2 by avoiding dynamic properties

### DIFF
--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -9,6 +9,9 @@ use React\Dns\Model\Message;
 
 class FunctionalResolverTest extends TestCase
 {
+    private $loop;
+    private $resolver;
+
     /**
      * @before
      */

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -8,6 +8,8 @@ use React\Tests\Dns\TestCase;
 
 class ParserTest extends TestCase
 {
+    private $parser;
+
     /**
      * @before
      */

--- a/tests/Query/SelectiveTransportExecutorTest.php
+++ b/tests/Query/SelectiveTransportExecutorTest.php
@@ -11,6 +11,10 @@ use React\Tests\Dns\TestCase;
 
 class SelectiveTransportExecutorTest extends TestCase
 {
+    private $datagram;
+    private $stream;
+    private $executor;
+
     /**
      * @before
      */


### PR DESCRIPTION
This simple changeset makes the test suite compatible with PHP 8.2 by avoiding dynamic properties. Note that this involves only changes to the test suite, as the project itself is already fully forward compatible. PHP 8.2 is still under active development and has not reached feature freeze yet, so I've decided against adding it to the test matrix at this point in time. After applying this changeset, the tests work just fine. Prior to this, the test output can easily be checked like this:

```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.2-rc-cli vendor/bin/phpunit
PHPUnit 9.5.20 #StandWithUkraine

....................................EEEEEEEEEEEEEEE............  63 / 280 ( 22%)
...EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE. 126 / 280 ( 45%)
........................................................EEEEEEE 189 / 280 ( 67%)
EE............................................................. 252 / 280 ( 90%)
............................                                    280 / 280 (100%)

Time: 00:01.309, Memory: 58.01 MB

There were 83 errors:

1) React\Tests\Dns\FunctionalResolverTest::testResolveLocalhostResolves
Creation of dynamic property React\Tests\Dns\FunctionalResolverTest::$loop is deprecated

/data/tests/FunctionalResolverTest.php:17

[…]

83) React\Tests\Dns\Query\SelectiveTransportExecutorTest::testRejectedPromiseAfterTruncatedResponseShouldNotCreateAnyGarbageReferences
Creation of dynamic property React\Tests\Dns\Query\SelectiveTransportExecutorTest::$datagram is deprecated

/data/tests/Query/SelectiveTransportExecutorTest.php:19

ERRORS!
Tests: 280, Assertions: 465, Errors: 83.
```

Refs https://github.com/reactphp/stream/pull/165 and #186