### PR TITLE
Optimize Promise v3 API compatibility to avoid hitting autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "react/cache": "^1.0 || ^0.6 || ^0.5",
         "react/event-loop": "^1.2",
         "react/promise": "^3.0 || ^2.7 || ^1.2.1",
-        "react/promise-timer": "^1.8"
+        "react/promise-timer": "^1.9"
     },
     "require-dev": {
         "clue/block-react": "^1.2",

--- a/src/Query/RetryExecutor.php
+++ b/src/Query/RetryExecutor.php
@@ -2,7 +2,6 @@
 
 namespace React\Dns\Query;
 
-use React\Promise\CancellablePromiseInterface;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 
@@ -25,7 +24,7 @@ final class RetryExecutor implements ExecutorInterface
     public function tryQuery(Query $query, $retries)
     {
         $deferred = new Deferred(function () use (&$promise) {
-            if ($promise instanceof CancellablePromiseInterface || (!\interface_exists('React\Promise\CancellablePromiseInterface') && \method_exists($promise, 'cancel'))) {
+            if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
                 $promise->cancel();
             }
         });


### PR DESCRIPTION
This minor changeset optimizes the Promise v3 API compatibility to avoid hitting the potentially expensive autoloader for each invocation. Instead of checking the `CancellablePromiseInterface` (removed in Promise v3 via https://github.com/reactphp/promise/pull/75), this now uses the same checks (duck-typing) also present in the `React\Promise\resolve()` function. This also improves static analysis and IDE support as it will no longer reference a class that will no longer be available in Promise v3.

Builds on top of #153, https://github.com/reactphp/promise-timer/pull/54 and https://github.com/reactphp/promise-timer/pull/55