### PR TITLE
Fix failing test suite by updating macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
 
   PHPUnit-macOS:
     name: PHPUnit (macOS)
-    runs-on: macos-10.15
+    runs-on: macos-12
     continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
           coverage: xdebug
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
See https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/ and https://github.com/actions/virtual-environments/issues/5583
Builds on top of #171 and #172