### PR TITLE
Template params can only have one argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See also the wiki for possible [cache implementations](https://github.com/reactp
 
 ### resolve()
 
-The `resolve(string $domain): PromiseInterface<string,Exception>` method can be used to
+The `resolve(string $domain): PromiseInterface<string>` method can be used to
 resolve the given $domain name to a single IPv4 address (type `A` query).
 
 ```php
@@ -151,7 +151,7 @@ $promise->cancel();
 
 ### resolveAll()
 
-The `resolveAll(string $host, int $type): PromiseInterface<array,Exception>` method can be used to
+The `resolveAll(string $host, int $type): PromiseInterface<array>` method can be used to
 resolve all record values for the given $domain name and query $type.
 
 ```php

--- a/src/Query/ExecutorInterface.php
+++ b/src/Query/ExecutorInterface.php
@@ -36,7 +36,7 @@ interface ExecutorInterface
      * ```
      *
      * @param Query $query
-     * @return \React\Promise\PromiseInterface<\React\Dns\Model\Message,\Exception>
+     * @return \React\Promise\PromiseInterface<\React\Dns\Model\Message>
      *     resolves with response message on success or rejects with an Exception on error
      */
     public function query(Query $query);

--- a/src/Resolver/ResolverInterface.php
+++ b/src/Resolver/ResolverInterface.php
@@ -39,7 +39,7 @@ interface ResolverInterface
      * ```
      *
      * @param string $domain
-     * @return \React\Promise\PromiseInterface<string,\Exception>
+     * @return \React\Promise\PromiseInterface<string>
      *     resolves with a single IP address on success or rejects with an Exception on error.
      */
     public function resolve($domain);
@@ -87,7 +87,7 @@ interface ResolverInterface
      * ```
      *
      * @param string $domain
-     * @return \React\Promise\PromiseInterface<array,\Exception>
+     * @return \React\Promise\PromiseInterface<array>
      *     Resolves with all record values on success or rejects with an Exception on error.
      */
     public function resolveAll($domain, $type);


### PR DESCRIPTION
The fact that a promise can also be rejected with a Throwable and/or Exception is implied and there is no need to also define that here.

Refs: https://github.com/reactphp/promise/pull/223