### PR TITLE
Include timeout logic to avoid dependency on reactphp/promise-timer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
         "php": ">=5.3.0",
         "react/cache": "^1.0 || ^0.6 || ^0.5",
         "react/event-loop": "^1.2",
-        "react/promise": "^3.0 || ^2.7 || ^1.2.1",
-        "react/promise-timer": "^1.9"
+        "react/promise": "^3.0 || ^2.7 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5 || ^4.8.35",
-        "react/async": "^4 || ^3 || ^2"
+        "react/async": "^4 || ^3 || ^2",
+        "react/promise-timer": "^1.9"
     },
     "autoload": {
         "psr-4": {

--- a/src/Query/TimeoutExecutor.php
+++ b/src/Query/TimeoutExecutor.php
@@ -4,7 +4,7 @@ namespace React\Dns\Query;
 
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
-use React\Promise\Timer;
+use React\Promise\Promise;
 
 final class TimeoutExecutor implements ExecutorInterface
 {
@@ -21,11 +21,49 @@ final class TimeoutExecutor implements ExecutorInterface
 
     public function query(Query $query)
     {
-        return Timer\timeout($this->executor->query($query), $this->timeout, $this->loop)->then(null, function ($e) use ($query) {
-            if ($e instanceof Timer\TimeoutException) {
-                $e = new TimeoutException(sprintf("DNS query for %s timed out", $query->describe()), 0, $e);
+        $promise = $this->executor->query($query);
+
+        $loop = $this->loop;
+        $time = $this->timeout;
+        return new Promise(function ($resolve, $reject) use ($loop, $time, $promise, $query) {
+            $timer = null;
+            $promise = $promise->then(function ($v) use (&$timer, $loop, $resolve) {
+                if ($timer) {
+                    $loop->cancelTimer($timer);
+                }
+                $timer = false;
+                $resolve($v);
+            }, function ($v) use (&$timer, $loop, $reject) {
+                if ($timer) {
+                    $loop->cancelTimer($timer);
+                }
+                $timer = false;
+                $reject($v);
+            });
+
+            // promise already resolved => no need to start timer
+            if ($timer === false) {
+                return;
             }
-            throw $e;
+
+            // start timeout timer which will cancel the pending promise
+            $timer = $loop->addTimer($time, function () use ($time, &$promise, $reject, $query) {
+                $reject(new TimeoutException(
+                    'DNS query for ' . $query->describe() . ' timed out'
+                ));
+
+                // Cancel pending query to clean up any underlying resources and references.
+                // Avoid garbage references in call stack by passing pending promise by reference.
+                assert(\method_exists($promise, 'cancel'));
+                $promise->cancel();
+                $promise = null;
+            });
+        }, function () use (&$promise) {
+            // Cancelling this promise will cancel the pending query, thus triggering the rejection logic above.
+            // Avoid garbage references in call stack by passing pending promise by reference.
+            assert(\method_exists($promise, 'cancel'));
+            $promise->cancel();
+            $promise = null;
         });
     }
 }


### PR DESCRIPTION
This changeset adds timeout logic to avoid the otherwise unneeded dependency on [reactphp/promise-timer](https://github.com/reactphp/promise-timer). There are plans to deprecate the reactphp/promise-stream package as discussed in https://github.com/orgs/reactphp/discussions/475 and in either case I'd like to remove additional dependencies where possible.

In particular, reactphp/dns and reactphp/socket appear to be the only ReactPHP packages that depend on reactphp/promise-timer at the moment. Most consumers of this package will likely install it as a dependency of reactphp/socket, so most consumers will likely continue installing this dependency until it is also removed from reactphp/socket. I have already prepared a similar follow-up PR for reactphp/socket to remove this dependency to ensure most consumers will no longer install reactphp/promise-timer by default.

This changeset does not otherwise affect our public API, so this should be safe to apply. The test suite confirms this has 100% code coverage and does not otherwise affect our APIs.

Note that this changeset does not preclude the discussion in https://github.com/orgs/reactphp/discussions/475, so whether or not or when the package will be deprecated is still up for debate. If you want to explicitly install this dependency, you can still install it like this:

```bash
composer require react/promise-timer
```

Builds on top of #204, #206 and others
See also https://github.com/reactphp/http/pull/482 for similar changes to remove reactphp/promise-stream from reactphp/http