### PR TITLE
Update to require PHP 7.1+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,6 @@ jobs:
           - 7.3
           - 7.2
           - 7.1
-          - 7.0
-          - 5.6
-          - 5.5
-          - 5.4
-          - 5.3
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
@@ -50,19 +45,3 @@ jobs:
           ini-file: development
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
-
-  PHPUnit-hhvm:
-    name: PHPUnit (HHVM)
-    runs-on: ubuntu-22.04
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
-      - name: Run hhvm composer.phar install
-        uses: docker://hhvm/hhvm:3.30-lts-latest
-        with:
-          args: hhvm composer.phar install
-      - name: Run hhvm vendor/bin/phpunit
-        uses: docker://hhvm/hhvm:3.30-lts-latest
-        with:
-          args: hhvm vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -424,8 +424,7 @@ composer require react/dns:^3@dev
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
-HHVM.
+extensions and supports running on PHP 7.1 through current PHP 8+.
 It's *highly recommended to use the latest supported PHP version* for this project.
 
 ## Tests

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.1",
         "react/cache": "^1.0 || ^0.6 || ^0.5",
         "react/event-loop": "^1.2",
         "react/promise": "^3.0 || ^2.7 || ^1.2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+        "phpunit/phpunit": "^9.6 || ^5.7",
         "react/async": "^4 || ^3 || ^2",
         "react/promise-timer": "^1.9"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "react/promise": "^3.0 || ^2.7 || ^1.2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^5.7",
+        "phpunit/phpunit": "^9.6 || ^7.5",
         "react/async": "^4 || ^3 || ^2",
         "react/promise-timer": "^1.9"
     },

--- a/examples/01-one.php
+++ b/examples/01-one.php
@@ -13,7 +13,7 @@ if (!$config->nameservers) {
 $factory = new Factory();
 $resolver = $factory->create($config);
 
-$name = isset($argv[1]) ? $argv[1] : 'www.google.com';
+$name = $argv[1] ?? 'www.google.com';
 
 $resolver->resolve($name)->then(function ($ip) use ($name) {
     echo 'IP for ' . $name . ': ' . $ip . PHP_EOL;

--- a/examples/02-concurrent.php
+++ b/examples/02-concurrent.php
@@ -15,7 +15,7 @@ $resolver = $factory->create($config);
 
 $names = array_slice($argv, 1);
 if (!$names) {
-    $names = array('google.com', 'www.google.com', 'gmail.com');
+    $names = ['google.com', 'www.google.com', 'gmail.com'];
 }
 
 foreach ($names as $name) {

--- a/examples/03-cached.php
+++ b/examples/03-cached.php
@@ -14,7 +14,7 @@ if (!$config->nameservers) {
 $factory = new Factory();
 $resolver = $factory->createCached($config);
 
-$name = isset($argv[1]) ? $argv[1] : 'www.google.com';
+$name = $argv[1] ?? 'www.google.com';
 
 $resolver->resolve($name)->then(function ($ip) use ($name) {
     echo 'IP for ' . $name . ': ' . $ip . PHP_EOL;

--- a/examples/11-all-ips.php
+++ b/examples/11-all-ips.php
@@ -14,7 +14,7 @@ if (!$config->nameservers) {
 $factory = new Factory();
 $resolver = $factory->create($config);
 
-$name = isset($argv[1]) ? $argv[1] : 'www.google.com';
+$name = $argv[1] ?? 'www.google.com';
 
 $resolver->resolveAll($name, Message::TYPE_A)->then(function (array $ips) use ($name) {
     echo 'IPv4 addresses for ' . $name . ': ' . implode(', ', $ips) . PHP_EOL;

--- a/examples/12-all-types.php
+++ b/examples/12-all-types.php
@@ -16,8 +16,8 @@ if (!$config->nameservers) {
 $factory = new Factory();
 $resolver = $factory->create($config);
 
-$name = isset($argv[1]) ? $argv[1] : 'google.com';
-$type = constant('React\Dns\Model\Message::TYPE_' . (isset($argv[2]) ? $argv[2] : 'TXT'));
+$name = $argv[1] ?? 'google.com';
+$type = constant('React\Dns\Model\Message::TYPE_' . ($argv[2] ?? 'TXT'));
 
 $resolver->resolveAll($name, $type)->then(function (array $values) {
     var_dump($values);

--- a/examples/13-reverse-dns.php
+++ b/examples/13-reverse-dns.php
@@ -14,7 +14,7 @@ if (!$config->nameservers) {
 $factory = new Factory();
 $resolver = $factory->create($config);
 
-$ip = isset($argv[1]) ? $argv[1] : '8.8.8.8';
+$ip = $argv[1] ?? '8.8.8.8';
 
 if (@inet_pton($ip) === false) {
     exit('Error: Given argument is not a valid IP' . PHP_EOL);

--- a/examples/91-query-a-and-aaaa.php
+++ b/examples/91-query-a-and-aaaa.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $executor = new UdpTransportExecutor('8.8.8.8:53');
 
-$name = isset($argv[1]) ? $argv[1] : 'www.google.com';
+$name = $argv[1] ?? 'www.google.com';
 
 $ipv4Query = new Query($name, Message::TYPE_A, Message::CLASS_IN);
 $ipv6Query = new Query($name, Message::TYPE_AAAA, Message::CLASS_IN);

--- a/examples/92-query-any.php
+++ b/examples/92-query-any.php
@@ -13,7 +13,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $executor = new TcpTransportExecutor('8.8.8.8:53');
 
-$name = isset($argv[1]) ? $argv[1] : 'google.com';
+$name = $argv[1] ?? 'google.com';
 
 $any = new Query($name, Message::TYPE_ANY, Message::CLASS_IN);
 

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -2,7 +2,7 @@
 
 <!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -2,7 +2,7 @@
 
 <!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -82,7 +82,7 @@ final class Config
             throw new RuntimeException('Unable to load resolv.conf file "' . $path . '"');
         }
 
-        $matches = array();
+        $matches = [];
         preg_match_all('/^nameserver\s+(\S+)\s*$/m', $contents, $matches);
 
         $config = new self();
@@ -133,5 +133,5 @@ final class Config
         return $config;
     }
 
-    public $nameservers = array();
+    public $nameservers = [];
 }

--- a/src/Config/HostsFile.php
+++ b/src/Config/HostsFile.php
@@ -98,7 +98,7 @@ class HostsFile
     {
         $name = strtolower($name);
 
-        $ips = array();
+        $ips = [];
         foreach (preg_split('/\r?\n/', $this->contents) as $line) {
             $parts = preg_split('/\s+/', $line);
             $ip = array_shift($parts);
@@ -128,10 +128,10 @@ class HostsFile
         // check binary representation of IP to avoid string case and short notation
         $ip = @inet_pton($ip);
         if ($ip === false) {
-            return array();
+            return [];
         }
 
-        $names = array();
+        $names = [];
         foreach (preg_split('/\r?\n/', $this->contents) as $line) {
             $parts = preg_split('/\s+/', $line, -1, PREG_SPLIT_NO_EMPTY);
             $addr = (string) array_shift($parts);

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -190,31 +190,31 @@ final class Message
      * An array of Query objects
      *
      * ```php
-     * $questions = array(
+     * $questions = [
      *     new Query(
      *         'reactphp.org',
      *         Message::TYPE_A,
      *         Message::CLASS_IN
      *     )
-     * );
+     * ];
      * ```
      *
      * @var Query[]
      */
-    public $questions = array();
+    public $questions = [];
 
     /**
      * @var Record[]
      */
-    public $answers = array();
+    public $answers = [];
 
     /**
      * @var Record[]
      */
-    public $authority = array();
+    public $authority = [];
 
     /**
      * @var Record[]
      */
-    public $additional = array();
+    public $additional = [];
 }

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -126,23 +126,13 @@ final class Message
      * DNS response messages can not guess the message ID to avoid possible
      * cache poisoning attacks.
      *
-     * The `random_int()` function is only available on PHP 7+ or when
-     * https://github.com/paragonie/random_compat is installed. As such, using
-     * the latest supported PHP version is highly recommended. This currently
-     * falls back to a less secure random number generator on older PHP versions
-     * in the hope that this system is properly protected against outside
-     * attackers, for example by using one of the common local DNS proxy stubs.
-     *
      * @return int
      * @see self::getId()
      * @codeCoverageIgnore
      */
     private static function generateId()
     {
-        if (function_exists('random_int')) {
-            return random_int(0, 0xffff);
-        }
-        return mt_rand(0, 0xffff);
+        return random_int(0, 0xffff);
     }
 
     /**

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -108,20 +108,20 @@ final class Parser
         list($labels, $consumed) = $this->readLabels($data, $consumed);
 
         if ($labels === null || !isset($data[$consumed + 4 - 1])) {
-            return array(null, null);
+            return [null, null];
         }
 
         list($type, $class) = array_values(unpack('n*', substr($data, $consumed, 4)));
         $consumed += 4;
 
-        return array(
+        return [
             new Query(
                 implode('.', $labels),
                 $type,
                 $class
             ),
             $consumed
-        );
+        ];
     }
 
     /**
@@ -134,7 +134,7 @@ final class Parser
         list($name, $consumed) = $this->readDomain($data, $consumed);
 
         if ($name === null || !isset($data[$consumed + 10 - 1])) {
-            return array(null, null);
+            return [null, null];
         }
 
         list($type, $class) = array_values(unpack('n*', substr($data, $consumed, 4)));
@@ -152,7 +152,7 @@ final class Parser
         $consumed += 2;
 
         if (!isset($data[$consumed + $rdLength - 1])) {
-            return array(null, null);
+            return [null, null];
         }
 
         $rdata = null;
@@ -171,7 +171,7 @@ final class Parser
         } elseif (Message::TYPE_CNAME === $type || Message::TYPE_PTR === $type || Message::TYPE_NS === $type) {
             list($rdata, $consumed) = $this->readDomain($data, $consumed);
         } elseif (Message::TYPE_TXT === $type || Message::TYPE_SPF === $type) {
-            $rdata = array();
+            $rdata = [];
             while ($consumed < $expected) {
                 $len = ord($data[$consumed]);
                 $rdata[] = (string)substr($data, $consumed + 1, $len);
@@ -182,22 +182,22 @@ final class Parser
                 list($priority) = array_values(unpack('n', substr($data, $consumed, 2)));
                 list($target, $consumed) = $this->readDomain($data, $consumed + 2);
 
-                $rdata = array(
+                $rdata = [
                     'priority' => $priority,
                     'target' => $target
-                );
+                ];
             }
         } elseif (Message::TYPE_SRV === $type) {
             if ($rdLength > 6) {
                 list($priority, $weight, $port) = array_values(unpack('n*', substr($data, $consumed, 6)));
                 list($target, $consumed) = $this->readDomain($data, $consumed + 6);
 
-                $rdata = array(
+                $rdata = [
                     'priority' => $priority,
                     'weight' => $weight,
                     'port' => $port,
                     'target' => $target
-                );
+                ];
             }
         } elseif (Message::TYPE_SSHFP === $type) {
             if ($rdLength > 2) {
@@ -205,11 +205,11 @@ final class Parser
                 $fingerprint = \bin2hex(\substr($data, $consumed + 2, $rdLength - 2));
                 $consumed += $rdLength;
 
-                $rdata = array(
+                $rdata = [
                     'algorithm' => $algorithm,
                     'type' => $hash,
                     'fingerprint' => $fingerprint
-                );
+                ];
             }
         } elseif (Message::TYPE_SOA === $type) {
             list($mname, $consumed) = $this->readDomain($data, $consumed);
@@ -219,7 +219,7 @@ final class Parser
                 list($serial, $refresh, $retry, $expire, $minimum) = array_values(unpack('N*', substr($data, $consumed, 20)));
                 $consumed += 20;
 
-                $rdata = array(
+                $rdata = [
                     'mname' => $mname,
                     'rname' => $rname,
                     'serial' => $serial,
@@ -227,10 +227,10 @@ final class Parser
                     'retry' => $retry,
                     'expire' => $expire,
                     'minimum' => $minimum
-                );
+                ];
             }
         } elseif (Message::TYPE_OPT === $type) {
-            $rdata = array();
+            $rdata = [];
             while (isset($data[$consumed + 4 - 1])) {
                 list($code, $length) = array_values(unpack('n*', substr($data, $consumed, 4)));
                 $value = (string) substr($data, $consumed + 4, $length);
@@ -254,11 +254,11 @@ final class Parser
                     $value = substr($data, $consumed + 2 + $tagLength, $rdLength - 2 - $tagLength);
                     $consumed += $rdLength;
 
-                    $rdata = array(
+                    $rdata = [
                         'flag' => $flag,
                         'tag' => $tag,
                         'value' => $value
-                    );
+                    ];
                 }
             }
         } else {
@@ -269,13 +269,13 @@ final class Parser
 
         // ensure parsing record data consumes expact number of bytes indicated in record length
         if ($consumed !== $expected || $rdata === null) {
-            return array(null, null);
+            return [null, null];
         }
 
-        return array(
+        return [
             new Record($name, $type, $class, $ttl, $rdata),
             $consumed
-        );
+        ];
     }
 
     private function readDomain($data, $consumed)
@@ -283,11 +283,11 @@ final class Parser
         list ($labels, $consumed) = $this->readLabels($data, $consumed);
 
         if ($labels === null) {
-            return array(null, null);
+            return [null, null];
         }
 
         // use escaped notation for each label part, then join using dots
-        return array(
+        return [
             \implode(
                 '.',
                 \array_map(
@@ -298,7 +298,7 @@ final class Parser
                 )
             ),
             $consumed
-        );
+        ];
     }
 
     /**
@@ -309,11 +309,11 @@ final class Parser
      */
     private function readLabels($data, $consumed, $compressionDepth = 127)
     {
-        $labels = array();
+        $labels = [];
 
         while (true) {
             if (!isset($data[$consumed])) {
-                return array(null, null);
+                return [null, null];
             }
 
             $length = \ord($data[$consumed]);
@@ -328,14 +328,14 @@ final class Parser
             if (($length & 0xc0) === 0xc0 && isset($data[$consumed + 1]) && $compressionDepth) {
                 $offset = ($length & ~0xc0) << 8 | \ord($data[$consumed + 1]);
                 if ($offset >= $consumed) {
-                    return array(null, null);
+                    return [null, null];
                 }
 
                 $consumed += 2;
                 list($newLabels) = $this->readLabels($data, $offset, $compressionDepth - 1);
 
                 if ($newLabels === null) {
-                    return array(null, null);
+                    return [null, null];
                 }
 
                 $labels = array_merge($labels, $newLabels);
@@ -344,13 +344,13 @@ final class Parser
 
             // length MUST be 0-63 (6 bits only) and data has to be large enough
             if ($length & 0xc0 || !isset($data[$consumed + $length - 1])) {
-                return array(null, null);
+                return [null, null];
             }
 
             $labels[] = substr($data, $consumed + 1, $length);
             $consumed += $length + 1;
         }
 
-        return array($labels, $consumed);
+        return [$labels, $consumed];
     }
 }

--- a/src/Query/FallbackExecutor.php
+++ b/src/Query/FallbackExecutor.php
@@ -18,11 +18,10 @@ final class FallbackExecutor implements ExecutorInterface
     public function query(Query $query)
     {
         $cancelled = false;
-        $fallback = $this->fallback;
         $promise = $this->executor->query($query);
 
-        return new Promise(function ($resolve, $reject) use (&$promise, $fallback, $query, &$cancelled) {
-            $promise->then($resolve, function (\Exception $e1) use ($fallback, $query, $resolve, $reject, &$cancelled, &$promise) {
+        return new Promise(function ($resolve, $reject) use (&$promise, $query, &$cancelled) {
+            $promise->then($resolve, function (\Exception $e1) use ($query, $resolve, $reject, &$cancelled, &$promise) {
                 // reject if primary resolution rejected due to cancellation
                 if ($cancelled) {
                     $reject($e1);
@@ -30,7 +29,7 @@ final class FallbackExecutor implements ExecutorInterface
                 }
 
                 // start fallback query if primary query rejected
-                $promise = $fallback->query($query)->then($resolve, function (\Exception $e2) use ($e1, $reject) {
+                $promise = $this->fallback->query($query)->then($resolve, function (\Exception $e2) use ($e1, $reject) {
                     $append = $e2->getMessage();
                     if (($pos = strpos($append, ':')) !== false) {
                         $append = substr($append, $pos + 2);

--- a/src/Query/HostsFileExecutor.php
+++ b/src/Query/HostsFileExecutor.php
@@ -5,7 +5,7 @@ namespace React\Dns\Query;
 use React\Dns\Config\HostsFile;
 use React\Dns\Model\Message;
 use React\Dns\Model\Record;
-use React\Promise;
+use function React\Promise\resolve;
 
 /**
  * Resolves hosts from the given HostsFile or falls back to another executor
@@ -29,7 +29,7 @@ final class HostsFileExecutor implements ExecutorInterface
     {
         if ($query->class === Message::CLASS_IN && ($query->type === Message::TYPE_A || $query->type === Message::TYPE_AAAA)) {
             // forward lookup for type A or AAAA
-            $records = array();
+            $records = [];
             $expectsColon = $query->type === Message::TYPE_AAAA;
             foreach ($this->hosts->getIpsForHost($query->name) as $ip) {
                 // ensure this is an IPv4/IPV6 address according to query type
@@ -39,7 +39,7 @@ final class HostsFileExecutor implements ExecutorInterface
             }
 
             if ($records) {
-                return Promise\resolve(
+                return resolve(
                     Message::createResponseWithAnswersForQuery($query, $records)
                 );
             }
@@ -48,13 +48,13 @@ final class HostsFileExecutor implements ExecutorInterface
             $ip = $this->getIpFromHost($query->name);
 
             if ($ip !== null) {
-                $records = array();
+                $records = [];
                 foreach ($this->hosts->getHostsForIp($ip) as $host) {
                     $records[] = new Record($query->name, $query->type, $query->class, 0, $host);
                 }
 
                 if ($records) {
-                    return Promise\resolve(
+                    return resolve(
                         Message::createResponseWithAnswersForQuery($query, $records)
                     );
                 }

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -56,7 +56,7 @@ final class Query
         $class = $this->class !== Message::CLASS_IN ? 'CLASS' . $this->class . ' ' : '';
 
         $type = 'TYPE' . $this->type;
-        $ref = new \ReflectionClass('React\Dns\Model\Message');
+        $ref = new \ReflectionClass(Message::class);
         foreach ($ref->getConstants() as $name => $value) {
             if ($value === $this->type && \strpos($name, 'TYPE_') === 0) {
                 $type = \substr($name, 5);

--- a/src/Query/RetryExecutor.php
+++ b/src/Query/RetryExecutor.php
@@ -34,8 +34,7 @@ final class RetryExecutor implements ExecutorInterface
             $deferred->resolve($value);
         };
 
-        $executor = $this->executor;
-        $errorback = function ($e) use ($deferred, &$promise, $query, $success, &$errorback, &$retries, $executor) {
+        $errorback = function ($e) use ($deferred, &$promise, $query, $success, &$errorback, &$retries) {
             if (!$e instanceof TimeoutException) {
                 $errorback = null;
                 $deferred->reject($e);
@@ -49,7 +48,7 @@ final class RetryExecutor implements ExecutorInterface
 
                 // avoid garbage references by replacing all closures in call stack.
                 // what a lovely piece of code!
-                $r = new \ReflectionProperty('Exception', 'trace');
+                $r = new \ReflectionProperty(\Exception::class, 'trace');
                 $r->setAccessible(true);
                 $trace = $r->getValue($e);
 
@@ -68,7 +67,7 @@ final class RetryExecutor implements ExecutorInterface
                 $r->setValue($e, $trace);
             } else {
                 --$retries;
-                $promise = $executor->query($query)->then(
+                $promise = $this->executor->query($query)->then(
                     $success,
                     $errorback
                 );

--- a/src/Query/SelectiveTransportExecutor.php
+++ b/src/Query/SelectiveTransportExecutor.php
@@ -63,15 +63,14 @@ class SelectiveTransportExecutor implements ExecutorInterface
 
     public function query(Query $query)
     {
-        $stream = $this->streamExecutor;
         $pending = $this->datagramExecutor->query($query);
 
-        return new Promise(function ($resolve, $reject) use (&$pending, $stream, $query) {
+        return new Promise(function ($resolve, $reject) use (&$pending, $query) {
             $pending->then(
                 $resolve,
-                function ($e) use (&$pending, $stream, $query, $resolve, $reject) {
+                function ($e) use (&$pending, $query, $resolve, $reject) {
                     if ($e->getCode() === (\defined('SOCKET_EMSGSIZE') ? \SOCKET_EMSGSIZE : 90)) {
-                        $pending = $stream->query($query)->then($resolve, $reject);
+                        $pending = $this->streamExecutor->query($query)->then($resolve, $reject);
                     } else {
                         $reject($e);
                     }

--- a/src/Query/TimeoutExecutor.php
+++ b/src/Query/TimeoutExecutor.php
@@ -23,19 +23,17 @@ final class TimeoutExecutor implements ExecutorInterface
     {
         $promise = $this->executor->query($query);
 
-        $loop = $this->loop;
-        $time = $this->timeout;
-        return new Promise(function ($resolve, $reject) use ($loop, $time, $promise, $query) {
+        return new Promise(function ($resolve, $reject) use ($promise, $query) {
             $timer = null;
-            $promise = $promise->then(function ($v) use (&$timer, $loop, $resolve) {
+            $promise = $promise->then(function ($v) use (&$timer, $resolve) {
                 if ($timer) {
-                    $loop->cancelTimer($timer);
+                    $this->loop->cancelTimer($timer);
                 }
                 $timer = false;
                 $resolve($v);
-            }, function ($v) use (&$timer, $loop, $reject) {
+            }, function ($v) use (&$timer, $reject) {
                 if ($timer) {
-                    $loop->cancelTimer($timer);
+                    $this->loop->cancelTimer($timer);
                 }
                 $timer = false;
                 $reject($v);
@@ -47,7 +45,7 @@ final class TimeoutExecutor implements ExecutorInterface
             }
 
             // start timeout timer which will cancel the pending promise
-            $timer = $loop->addTimer($time, function () use ($time, &$promise, $reject, $query) {
+            $timer = $this->loop->addTimer($this->timeout, function () use (&$promise, $reject, $query) {
                 $reject(new TimeoutException(
                     'DNS query for ' . $query->describe() . ' timed out'
                 ));

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -29,12 +29,11 @@ final class Resolver implements ResolverInterface
     public function resolveAll($domain, $type)
     {
         $query = new Query($domain, $type, Message::CLASS_IN);
-        $that = $this;
 
         return $this->executor->query(
             $query
-        )->then(function (Message $response) use ($query, $that) {
-            return $that->extractValues($query, $response);
+        )->then(function (Message $response) use ($query) {
+            return $this->extractValues($query, $response);
         });
     }
 

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -29,7 +29,7 @@ class ConfigTest extends TestCase
     {
         $config = Config::loadResolvConfBlocking(__DIR__ . '/../Fixtures/etc/resolv.conf');
 
-        $this->assertEquals(array('8.8.8.8'), $config->nameservers);
+        $this->assertEquals(['8.8.8.8'], $config->nameservers);
     }
 
     public function testLoadThrowsWhenPathIsInvalid()
@@ -41,7 +41,7 @@ class ConfigTest extends TestCase
     public function testParsesSingleEntryFile()
     {
         $contents = 'nameserver 8.8.8.8';
-        $expected = array('8.8.8.8');
+        $expected = ['8.8.8.8'];
 
         $config = Config::loadResolvConfBlocking('data://text/plain;base64,' . base64_encode($contents));
         $this->assertEquals($expected, $config->nameservers);
@@ -50,7 +50,7 @@ class ConfigTest extends TestCase
     public function testParsesNameserverWithoutIpv6ScopeId()
     {
         $contents = 'nameserver ::1%lo';
-        $expected = array('::1');
+        $expected = ['::1'];
 
         $config = Config::loadResolvConfBlocking('data://text/plain;base64,' . base64_encode($contents));
         $this->assertEquals($expected, $config->nameservers);
@@ -71,7 +71,7 @@ domain v.cablecom.net
 nameserver 127.0.0.1
 nameserver ::1
 ';
-        $expected = array('127.0.0.1', '::1');
+        $expected = ['127.0.0.1', '::1'];
 
         $config = Config::loadResolvConfBlocking('data://text/plain;base64,' . base64_encode($contents));
         $this->assertEquals($expected, $config->nameservers);
@@ -79,7 +79,7 @@ nameserver ::1
 
     public function testParsesEmptyFileWithoutNameserverEntries()
     {
-        $expected = array();
+        $expected = [];
 
         $config = Config::loadResolvConfBlocking('data://text/plain;base64,');
         $this->assertEquals($expected, $config->nameservers);
@@ -97,7 +97,7 @@ nameserver 4.5.6.7 5.6.7.8
 NameServer 7.8.9.10
 nameserver localhost
 ';
-        $expected = array();
+        $expected = [];
 
         $config = Config::loadResolvConfBlocking('data://text/plain;base64,' . base64_encode($contents));
         $this->assertEquals($expected, $config->nameservers);
@@ -126,7 +126,7 @@ ACE,
 ACE,{192.168.2.1}
 ACE,
 ';
-        $expected = array('192.168.2.1');
+        $expected = ['192.168.2.1'];
 
         $config = Config::loadWmicBlocking($this->echoCommand($contents));
 
@@ -139,7 +139,7 @@ ACE,
 Node,DNSServerSearchOrder
 ACE,
 ';
-        $expected = array();
+        $expected = [];
 
         $config = Config::loadWmicBlocking($this->echoCommand($contents));
 
@@ -156,7 +156,7 @@ ACE,
 ACE,{192.168.2.2}
 ACE,
 ';
-        $expected = array('192.168.2.1', '192.168.2.2');
+        $expected = ['192.168.2.1', '192.168.2.2'];
 
         $config = Config::loadWmicBlocking($this->echoCommand($contents));
 
@@ -171,7 +171,7 @@ ACE,
 ACE,{192.168.2.1;192.168.2.2}
 ACE,
 ';
-        $expected = array('192.168.2.1', '192.168.2.2');
+        $expected = ['192.168.2.1', '192.168.2.2'];
 
         $config = Config::loadWmicBlocking($this->echoCommand($contents));
 
@@ -186,7 +186,7 @@ ACE,
 ACE,{"192.168.2.1","192.168.2.2"}
 ACE,
 ';
-        $expected = array('192.168.2.1', '192.168.2.2');
+        $expected = ['192.168.2.1', '192.168.2.2'];
 
         $config = Config::loadWmicBlocking($this->echoCommand($contents));
 

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -2,8 +2,8 @@
 
 namespace React\Tests\Dns\Config;
 
-use React\Tests\Dns\TestCase;
 use React\Dns\Config\Config;
+use React\Tests\Dns\TestCase;
 
 class ConfigTest extends TestCase
 {
@@ -11,7 +11,7 @@ class ConfigTest extends TestCase
     {
         $config = Config::loadSystemConfigBlocking();
 
-        $this->assertInstanceOf('React\Dns\Config\Config', $config);
+        $this->assertInstanceOf(Config::class, $config);
     }
 
     public function testLoadsDefaultPath()
@@ -22,7 +22,7 @@ class ConfigTest extends TestCase
 
         $config = Config::loadResolvConfBlocking();
 
-        $this->assertInstanceOf('React\Dns\Config\Config', $config);
+        $this->assertInstanceOf(Config::class, $config);
     }
 
     public function testLoadsFromExplicitPath()
@@ -34,7 +34,7 @@ class ConfigTest extends TestCase
 
     public function testLoadThrowsWhenPathIsInvalid()
     {
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         Config::loadResolvConfBlocking(__DIR__ . '/invalid.conf');
     }
 
@@ -115,7 +115,7 @@ nameserver localhost
 
         $config = Config::loadWmicBlocking();
 
-        $this->assertInstanceOf('React\Dns\Config\Config', $config);
+        $this->assertInstanceOf(Config::class, $config);
     }
 
     public function testLoadsSingleEntryFromWmicOutput()

--- a/tests/Config/HostsFileTest.php
+++ b/tests/Config/HostsFileTest.php
@@ -35,134 +35,134 @@ class HostsFileTest extends TestCase
     {
         $hosts = new HostsFile('127.0.0.1 localhost');
 
-        $this->assertEquals(array('127.0.0.1'), $hosts->getIpsForHost('localhost'));
-        $this->assertEquals(array(), $hosts->getIpsForHost('example.com'));
+        $this->assertEquals(['127.0.0.1'], $hosts->getIpsForHost('localhost'));
+        $this->assertEquals([], $hosts->getIpsForHost('example.com'));
     }
 
     public function testNonIpReturnsNothingForInvalidHosts()
     {
         $hosts = new HostsFile('a b');
 
-        $this->assertEquals(array(), $hosts->getIpsForHost('a'));
-        $this->assertEquals(array(), $hosts->getIpsForHost('b'));
+        $this->assertEquals([], $hosts->getIpsForHost('a'));
+        $this->assertEquals([], $hosts->getIpsForHost('b'));
     }
 
     public function testIgnoresIpv6ZoneId()
     {
         $hosts = new HostsFile('fe80::1%lo0 localhost');
 
-        $this->assertEquals(array('fe80::1'), $hosts->getIpsForHost('localhost'));
+        $this->assertEquals(['fe80::1'], $hosts->getIpsForHost('localhost'));
     }
 
     public function testSkipsComments()
     {
         $hosts = new HostsFile('# start' . PHP_EOL .'#127.0.0.1 localhost' . PHP_EOL . '127.0.0.2 localhost # example.com');
 
-        $this->assertEquals(array('127.0.0.2'), $hosts->getIpsForHost('localhost'));
-        $this->assertEquals(array(), $hosts->getIpsForHost('example.com'));
+        $this->assertEquals(['127.0.0.2'], $hosts->getIpsForHost('localhost'));
+        $this->assertEquals([], $hosts->getIpsForHost('example.com'));
     }
 
     public function testContainsSingleLocalhostEntryWithCaseIgnored()
     {
         $hosts = new HostsFile('127.0.0.1 LocalHost');
 
-        $this->assertEquals(array('127.0.0.1'), $hosts->getIpsForHost('LOCALHOST'));
+        $this->assertEquals(['127.0.0.1'], $hosts->getIpsForHost('LOCALHOST'));
     }
 
     public function testEmptyFileContainsNothing()
     {
         $hosts = new HostsFile('');
 
-        $this->assertEquals(array(), $hosts->getIpsForHost('example.com'));
+        $this->assertEquals([], $hosts->getIpsForHost('example.com'));
     }
 
     public function testSingleEntryWithMultipleNames()
     {
         $hosts = new HostsFile('127.0.0.1 localhost example.com');
 
-        $this->assertEquals(array('127.0.0.1'), $hosts->getIpsForHost('example.com'));
-        $this->assertEquals(array('127.0.0.1'), $hosts->getIpsForHost('localhost'));
+        $this->assertEquals(['127.0.0.1'], $hosts->getIpsForHost('example.com'));
+        $this->assertEquals(['127.0.0.1'], $hosts->getIpsForHost('localhost'));
     }
 
     public function testMergesEntriesOverMultipleLines()
     {
         $hosts = new HostsFile("127.0.0.1 localhost\n127.0.0.2 localhost\n127.0.0.3 a localhost b\n127.0.0.4 a localhost");
 
-        $this->assertEquals(array('127.0.0.1', '127.0.0.2', '127.0.0.3', '127.0.0.4'), $hosts->getIpsForHost('localhost'));
+        $this->assertEquals(['127.0.0.1', '127.0.0.2', '127.0.0.3', '127.0.0.4'], $hosts->getIpsForHost('localhost'));
     }
 
     public function testMergesIpv4AndIpv6EntriesOverMultipleLines()
     {
         $hosts = new HostsFile("127.0.0.1 localhost\n::1 localhost");
 
-        $this->assertEquals(array('127.0.0.1', '::1'), $hosts->getIpsForHost('localhost'));
+        $this->assertEquals(['127.0.0.1', '::1'], $hosts->getIpsForHost('localhost'));
     }
 
     public function testReverseLookup()
     {
         $hosts = new HostsFile('127.0.0.1 localhost');
 
-        $this->assertEquals(array('localhost'), $hosts->getHostsForIp('127.0.0.1'));
-        $this->assertEquals(array(), $hosts->getHostsForIp('192.168.1.1'));
+        $this->assertEquals(['localhost'], $hosts->getHostsForIp('127.0.0.1'));
+        $this->assertEquals([], $hosts->getHostsForIp('192.168.1.1'));
     }
 
     public function testReverseSkipsComments()
     {
         $hosts = new HostsFile("# start\n#127.0.0.1 localhosted\n127.0.0.2\tlocalhost\t# example.com\n\t127.0.0.3\t\texample.org\t\t");
 
-        $this->assertEquals(array(), $hosts->getHostsForIp('127.0.0.1'));
-        $this->assertEquals(array('localhost'), $hosts->getHostsForIp('127.0.0.2'));
-        $this->assertEquals(array('example.org'), $hosts->getHostsForIp('127.0.0.3'));
+        $this->assertEquals([], $hosts->getHostsForIp('127.0.0.1'));
+        $this->assertEquals(['localhost'], $hosts->getHostsForIp('127.0.0.2'));
+        $this->assertEquals(['example.org'], $hosts->getHostsForIp('127.0.0.3'));
     }
 
     public function testReverseNonIpReturnsNothing()
     {
         $hosts = new HostsFile('127.0.0.1 localhost');
 
-        $this->assertEquals(array(), $hosts->getHostsForIp('localhost'));
-        $this->assertEquals(array(), $hosts->getHostsForIp('127.0.0.1.1'));
+        $this->assertEquals([], $hosts->getHostsForIp('localhost'));
+        $this->assertEquals([], $hosts->getHostsForIp('127.0.0.1.1'));
     }
 
     public function testReverseNonIpReturnsNothingForInvalidHosts()
     {
         $hosts = new HostsFile('a b');
 
-        $this->assertEquals(array(), $hosts->getHostsForIp('a'));
-        $this->assertEquals(array(), $hosts->getHostsForIp('b'));
+        $this->assertEquals([], $hosts->getHostsForIp('a'));
+        $this->assertEquals([], $hosts->getHostsForIp('b'));
     }
 
     public function testReverseLookupReturnsLowerCaseHost()
     {
         $hosts = new HostsFile('127.0.0.1 LocalHost');
 
-        $this->assertEquals(array('localhost'), $hosts->getHostsForIp('127.0.0.1'));
+        $this->assertEquals(['localhost'], $hosts->getHostsForIp('127.0.0.1'));
     }
 
     public function testReverseLookupChecksNormalizedIpv6()
     {
         $hosts = new HostsFile('FE80::00a1 localhost');
 
-        $this->assertEquals(array('localhost'), $hosts->getHostsForIp('fe80::A1'));
+        $this->assertEquals(['localhost'], $hosts->getHostsForIp('fe80::A1'));
     }
 
     public function testReverseLookupIgnoresIpv6ZoneId()
     {
         $hosts = new HostsFile('fe80::1%lo0 localhost');
 
-        $this->assertEquals(array('localhost'), $hosts->getHostsForIp('fe80::1'));
+        $this->assertEquals(['localhost'], $hosts->getHostsForIp('fe80::1'));
     }
 
     public function testReverseLookupReturnsMultipleHostsOverSingleLine()
     {
         $hosts = new HostsFile("::1 ip6-localhost ip6-loopback");
 
-        $this->assertEquals(array('ip6-localhost', 'ip6-loopback'), $hosts->getHostsForIp('::1'));
+        $this->assertEquals(['ip6-localhost', 'ip6-loopback'], $hosts->getHostsForIp('::1'));
     }
 
     public function testReverseLookupReturnsMultipleHostsOverMultipleLines()
     {
         $hosts = new HostsFile("::1 ip6-localhost\n::1 ip6-loopback");
 
-        $this->assertEquals(array('ip6-localhost', 'ip6-loopback'), $hosts->getHostsForIp('::1'));
+        $this->assertEquals(['ip6-localhost', 'ip6-loopback'], $hosts->getHostsForIp('::1'));
     }
 }

--- a/tests/Config/HostsFileTest.php
+++ b/tests/Config/HostsFileTest.php
@@ -2,8 +2,8 @@
 
 namespace React\Tests\Dns\Config;
 
-use React\Tests\Dns\TestCase;
 use React\Dns\Config\HostsFile;
+use React\Tests\Dns\TestCase;
 
 class HostsFileTest extends TestCase
 {
@@ -11,7 +11,7 @@ class HostsFileTest extends TestCase
     {
         $hosts = HostsFile::loadFromPathBlocking();
 
-        $this->assertInstanceOf('React\Dns\Config\HostsFile', $hosts);
+        $this->assertInstanceOf(HostsFile::class, $hosts);
     }
 
     public function testDefaultShouldHaveLocalhostMapped()
@@ -27,7 +27,7 @@ class HostsFileTest extends TestCase
 
     public function testLoadThrowsForInvalidPath()
     {
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         HostsFile::loadFromPathBlocking('does/not/exist');
     }
 

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -123,9 +123,6 @@ class FunctionalResolverTest extends TestCase
 
     public function testResolveCancelledRejectsImmediately()
     {
-        // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
-        ini_set('xdebug.max_nesting_level', 256);
-
         $promise = $this->resolver->resolve('google.com');
         $promise->cancel();
 

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -2,8 +2,10 @@
 
 namespace React\Tests\Dns;
 
-use React\Dns\Resolver\Factory;
 use React\Dns\Model\Message;
+use React\Dns\Query\CancellationException;
+use React\Dns\RecordNotFoundException;
+use React\Dns\Resolver\Factory;
 use React\EventLoop\Loop;
 
 class FunctionalResolverTest extends TestCase
@@ -116,7 +118,7 @@ class FunctionalResolverTest extends TestCase
         });
 
         /** @var \React\Dns\RecordNotFoundException $exception */
-        $this->assertInstanceOf('React\Dns\RecordNotFoundException', $exception);
+        $this->assertInstanceOf(RecordNotFoundException::class, $exception);
         $this->assertEquals('DNS query for example.invalid (A) returned an error response (Non-Existent Domain / NXDOMAIN)', $exception->getMessage());
         $this->assertEquals(Message::RCODE_NAME_ERROR, $exception->getCode());
     }
@@ -138,7 +140,7 @@ class FunctionalResolverTest extends TestCase
         });
 
         /** @var \React\Dns\Query\CancellationException $exception */
-        $this->assertInstanceOf('React\Dns\Query\CancellationException', $exception);
+        $this->assertInstanceOf(CancellationException::class, $exception);
         $this->assertEquals('DNS query for google.com (A) has been cancelled', $exception->getMessage());
     }
 
@@ -157,7 +159,7 @@ class FunctionalResolverTest extends TestCase
         });
 
         /** @var \React\Dns\RecordNotFoundException $exception */
-        $this->assertInstanceOf('React\Dns\RecordNotFoundException', $exception);
+        $this->assertInstanceOf(RecordNotFoundException::class, $exception);
         $this->assertEquals('DNS query for google.com (PTR) did not return a valid answer (NOERROR / NODATA)', $exception->getMessage());
         $this->assertEquals(0, $exception->getCode());
     }

--- a/tests/Model/MessageTest.php
+++ b/tests/Model/MessageTest.php
@@ -20,7 +20,7 @@ class MessageTest extends TestCase
     public function testCreateResponseWithNoAnswers()
     {
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
-        $answers = array();
+        $answers = [];
         $request = Message::createResponseWithAnswersForQuery($query, $answers);
 
         $this->assertTrue($request->qr);

--- a/tests/Protocol/BinaryDumperTest.php
+++ b/tests/Protocol/BinaryDumperTest.php
@@ -87,7 +87,7 @@ class BinaryDumperTest extends TestCase
             Message::CLASS_IN
         );
 
-        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, array());
+        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, []);
 
         $dumper = new BinaryDumper();
         $data = $dumper->toBinary($request);
@@ -118,9 +118,9 @@ class BinaryDumperTest extends TestCase
             Message::CLASS_IN
         );
 
-        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, array(
+        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, [
             Message::OPT_TCP_KEEPALIVE => null,
-        ));
+        ]);
 
         $dumper = new BinaryDumper();
         $data = $dumper->toBinary($request);
@@ -151,9 +151,9 @@ class BinaryDumperTest extends TestCase
             Message::CLASS_IN
         );
 
-        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, array(
+        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, [
             Message::OPT_TCP_KEEPALIVE => 1.2,
-        ));
+        ]);
 
         $dumper = new BinaryDumper();
         $data = $dumper->toBinary($request);
@@ -184,9 +184,9 @@ class BinaryDumperTest extends TestCase
             Message::CLASS_IN
         );
 
-        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, array(
+        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, [
             Message::OPT_PADDING => "\x00\x00"
-        ));
+        ]);
 
         $dumper = new BinaryDumper();
         $data = $dumper->toBinary($request);
@@ -218,10 +218,10 @@ class BinaryDumperTest extends TestCase
             Message::CLASS_IN
         );
 
-        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, array(
+        $request->additional[] = new Record('', Message::TYPE_OPT, 1000, 0, [
             0xa0 => 'foo',
             0x01 => "\x00\x00"
-        ));
+        ]);
 
         $dumper = new BinaryDumper();
         $data = $dumper->toBinary($request);
@@ -282,12 +282,12 @@ class BinaryDumperTest extends TestCase
             Message::CLASS_IN
         );
 
-        $response->answers[] = new Record('igor.io', Message::TYPE_SRV, Message::CLASS_IN, 86400, array(
+        $response->answers[] = new Record('igor.io', Message::TYPE_SRV, Message::CLASS_IN, 86400, [
             'priority' => 10,
             'weight' => 20,
             'port' => 8080,
             'target' => 'test'
-        ));
+        ]);
 
         $dumper = new BinaryDumper();
         $data = $dumper->toBinary($response);
@@ -324,7 +324,7 @@ class BinaryDumperTest extends TestCase
             Message::CLASS_IN
         );
 
-        $response->answers[] = new Record('igor.io', Message::TYPE_SOA, Message::CLASS_IN, 86400, array(
+        $response->answers[] = new Record('igor.io', Message::TYPE_SOA, Message::CLASS_IN, 86400, [
             'mname' => 'ns.hello',
             'rname' => 'e.hello',
             'serial' => 2018060501,
@@ -332,7 +332,7 @@ class BinaryDumperTest extends TestCase
             'retry' => 3600,
             'expire' => 605800,
             'minimum' => 3600
-        ));
+        ]);
 
         $dumper = new BinaryDumper();
         $data = $dumper->toBinary($response);
@@ -433,11 +433,11 @@ class BinaryDumperTest extends TestCase
 
         $response->answers[] = new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 0, '127.0.0.1');
         $response->answers[] = new Record('igor.io', Message::TYPE_AAAA, Message::CLASS_IN, 0, '::1');
-        $response->answers[] = new Record('igor.io', Message::TYPE_TXT, Message::CLASS_IN, 0, array('hello', 'world'));
-        $response->answers[] = new Record('igor.io', Message::TYPE_SPF, Message::CLASS_IN, 0, array('v=spf1 -all'));
-        $response->answers[] = new Record('igor.io', Message::TYPE_MX, Message::CLASS_IN, 0, array('priority' => 0, 'target' => ''));
-        $response->answers[] = new Record('igor.io', Message::TYPE_CAA, Message::CLASS_IN, 0, array('flag' => 0, 'tag' => 'issue', 'value' => 'letsencrypt.org'));
-        $response->answers[] = new Record('igor.io', Message::TYPE_SSHFP, Message::CLASS_IN, 0, array('algorithm' => 1, 'type' => '1', 'fingerprint' => '69ac090c'));
+        $response->answers[] = new Record('igor.io', Message::TYPE_TXT, Message::CLASS_IN, 0, ['hello', 'world']);
+        $response->answers[] = new Record('igor.io', Message::TYPE_SPF, Message::CLASS_IN, 0, ['v=spf1 -all']);
+        $response->answers[] = new Record('igor.io', Message::TYPE_MX, Message::CLASS_IN, 0, ['priority' => 0, 'target' => '']);
+        $response->answers[] = new Record('igor.io', Message::TYPE_CAA, Message::CLASS_IN, 0, ['flag' => 0, 'tag' => 'issue', 'value' => 'letsencrypt.org']);
+        $response->answers[] = new Record('igor.io', Message::TYPE_SSHFP, Message::CLASS_IN, 0, ['algorithm' => 1, 'type' => '1', 'fingerprint' => '69ac090c']);
 
         $dumper = new BinaryDumper();
         $data = $dumper->toBinary($response);

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -28,12 +28,12 @@ class ParserTest extends TestCase
 
     public function provideConvertTcpDumpToBinary()
     {
-        return array(
-            array(chr(0x72).chr(0x62), "72 62"),
-            array(chr(0x72).chr(0x62).chr(0x01).chr(0x00), "72 62 01 00"),
-            array(chr(0x72).chr(0x62).chr(0x01).chr(0x00).chr(0x00).chr(0x01), "72 62 01 00 00 01"),
-            array(chr(0x01).chr(0x00).chr(0x01), "01 00 01"),
-        );
+        return [
+            [chr(0x72).chr(0x62), "72 62"],
+            [chr(0x72).chr(0x62).chr(0x01).chr(0x00), "72 62 01 00"],
+            [chr(0x72).chr(0x62).chr(0x01).chr(0x00).chr(0x00).chr(0x01), "72 62 01 00 00 01"],
+            [chr(0x01).chr(0x00).chr(0x01), "01 00 01"],
+        ];
     }
 
     public function testParseRequest()
@@ -304,7 +304,7 @@ class ParserTest extends TestCase
         $this->assertSame(Message::TYPE_TXT, $response->answers[0]->type);
         $this->assertSame(Message::CLASS_IN, $response->answers[0]->class);
         $this->assertSame(86400, $response->answers[0]->ttl);
-        $this->assertSame(array('hello'), $response->answers[0]->data);
+        $this->assertSame(['hello'], $response->answers[0]->data);
     }
 
     public function testParseSPFResponse()
@@ -323,7 +323,7 @@ class ParserTest extends TestCase
         $this->assertSame(Message::TYPE_SPF, $response->answers[0]->type);
         $this->assertSame(Message::CLASS_IN, $response->answers[0]->class);
         $this->assertSame(86400, $response->answers[0]->ttl);
-        $this->assertSame(array('hello'), $response->answers[0]->data);
+        $this->assertSame(['hello'], $response->answers[0]->data);
     }
 
     public function testParseTXTResponseMultiple()
@@ -342,7 +342,7 @@ class ParserTest extends TestCase
         $this->assertSame(Message::TYPE_TXT, $response->answers[0]->type);
         $this->assertSame(Message::CLASS_IN, $response->answers[0]->class);
         $this->assertSame(86400, $response->answers[0]->ttl);
-        $this->assertSame(array('hello', 'world'), $response->answers[0]->data);
+        $this->assertSame(['hello', 'world'], $response->answers[0]->data);
     }
 
     public function testParseMXResponse()
@@ -361,7 +361,7 @@ class ParserTest extends TestCase
         $this->assertSame(Message::TYPE_MX, $response->answers[0]->type);
         $this->assertSame(Message::CLASS_IN, $response->answers[0]->class);
         $this->assertSame(86400, $response->answers[0]->ttl);
-        $this->assertSame(array('priority' => 10, 'target' => 'hello'), $response->answers[0]->data);
+        $this->assertSame(['priority' => 10, 'target' => 'hello'], $response->answers[0]->data);
     }
 
     public function testParseSRVResponse()
@@ -381,12 +381,12 @@ class ParserTest extends TestCase
         $this->assertSame(Message::CLASS_IN, $response->answers[0]->class);
         $this->assertSame(86400, $response->answers[0]->ttl);
         $this->assertSame(
-            array(
+            [
                 'priority' => 10,
                 'weight' => 20,
                 'port' => 8080,
                 'target' => 'test'
-            ),
+            ],
             $response->answers[0]->data
         );
     }
@@ -557,7 +557,7 @@ class ParserTest extends TestCase
         $this->assertSame(Message::TYPE_SSHFP, $response->answers[0]->type);
         $this->assertSame(Message::CLASS_IN, $response->answers[0]->class);
         $this->assertSame(86400, $response->answers[0]->ttl);
-        $this->assertSame(array('algorithm' => 1, 'type' => 1, 'fingerprint' => '69ac090c'), $response->answers[0]->data);
+        $this->assertSame(['algorithm' => 1, 'type' => 1, 'fingerprint' => '69ac090c'], $response->answers[0]->data);
     }
 
     public function testParseOptResponseWithoutOptions()
@@ -575,7 +575,7 @@ class ParserTest extends TestCase
         $this->assertSame(Message::TYPE_OPT, $response->answers[0]->type);
         $this->assertSame(1000, $response->answers[0]->class);
         $this->assertSame(0, $response->answers[0]->ttl);
-        $this->assertSame(array(), $response->answers[0]->data);
+        $this->assertSame([], $response->answers[0]->data);
     }
 
     public function testParseOptResponseWithOptTcpKeepaliveDesired()
@@ -594,7 +594,7 @@ class ParserTest extends TestCase
         $this->assertSame(Message::TYPE_OPT, $response->answers[0]->type);
         $this->assertSame(1000, $response->answers[0]->class);
         $this->assertSame(0, $response->answers[0]->ttl);
-        $this->assertSame(array(Message::OPT_TCP_KEEPALIVE => null), $response->answers[0]->data);
+        $this->assertSame([Message::OPT_TCP_KEEPALIVE => null], $response->answers[0]->data);
     }
 
     public function testParseOptResponseWithOptTcpKeepaliveGiven()
@@ -613,7 +613,7 @@ class ParserTest extends TestCase
         $this->assertSame(Message::TYPE_OPT, $response->answers[0]->type);
         $this->assertSame(1000, $response->answers[0]->class);
         $this->assertSame(0, $response->answers[0]->ttl);
-        $this->assertSame(array(Message::OPT_TCP_KEEPALIVE => 1.2), $response->answers[0]->data);
+        $this->assertSame([Message::OPT_TCP_KEEPALIVE => 1.2], $response->answers[0]->data);
     }
 
     public function testParseOptResponseWithCustomOptions()
@@ -633,7 +633,7 @@ class ParserTest extends TestCase
         $this->assertSame(Message::TYPE_OPT, $response->answers[0]->type);
         $this->assertSame(1000, $response->answers[0]->class);
         $this->assertSame(0, $response->answers[0]->ttl);
-        $this->assertSame(array(0xa0 => 'foo', 0x01 => ''), $response->answers[0]->data);
+        $this->assertSame([0xa0 => 'foo', 0x01 => ''], $response->answers[0]->data);
     }
 
     public function testParseSOAResponse()
@@ -656,7 +656,7 @@ class ParserTest extends TestCase
         $this->assertSame(Message::CLASS_IN, $response->answers[0]->class);
         $this->assertSame(86400, $response->answers[0]->ttl);
         $this->assertSame(
-            array(
+            [
                 'mname' => 'ns.hello',
                 'rname' => 'e.hello',
                 'serial' => 2018060501,
@@ -664,7 +664,7 @@ class ParserTest extends TestCase
                 'retry' => 3600,
                 'expire' => 604800,
                 'minimum' => 3600
-            ),
+            ],
             $response->answers[0]->data
         );
     }
@@ -686,7 +686,7 @@ class ParserTest extends TestCase
         $this->assertSame(Message::TYPE_CAA, $response->answers[0]->type);
         $this->assertSame(Message::CLASS_IN, $response->answers[0]->class);
         $this->assertSame(86400, $response->answers[0]->ttl);
-        $this->assertSame(array('flag' => 0, 'tag' => 'issue', 'value' => 'letsencrypt.org'), $response->answers[0]->data);
+        $this->assertSame(['flag' => 0, 'tag' => 'issue', 'value' => 'letsencrypt.org'], $response->answers[0]->data);
     }
 
     public function testParsePTRResponse()

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -28,12 +28,10 @@ class ParserTest extends TestCase
 
     public function provideConvertTcpDumpToBinary()
     {
-        return [
-            [chr(0x72).chr(0x62), "72 62"],
-            [chr(0x72).chr(0x62).chr(0x01).chr(0x00), "72 62 01 00"],
-            [chr(0x72).chr(0x62).chr(0x01).chr(0x00).chr(0x00).chr(0x01), "72 62 01 00 00 01"],
-            [chr(0x01).chr(0x00).chr(0x01), "01 00 01"],
-        ];
+        yield [chr(0x72).chr(0x62), "72 62"];
+        yield [chr(0x72).chr(0x62).chr(0x01).chr(0x00), "72 62 01 00"];
+        yield [chr(0x72).chr(0x62).chr(0x01).chr(0x00).chr(0x00).chr(0x01), "72 62 01 00 00 01"];
+        yield [chr(0x01).chr(0x00).chr(0x01), "01 00 01"];
     }
 
     public function testParseRequest()
@@ -768,7 +766,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -780,7 +778,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -792,7 +790,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -804,7 +802,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -816,7 +814,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -828,7 +826,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -840,7 +838,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -852,7 +850,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -866,7 +864,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -880,7 +878,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -894,7 +892,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -911,7 +909,7 @@ class ParserTest extends TestCase
 
         $data = $this->convertTcpDumpToBinary($data);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parser->parseMessage($data);
     }
 
@@ -923,7 +921,7 @@ class ParserTest extends TestCase
         $data .= "00 01 51 80";                         // answer: ttl 86400
         $data .= "00 00";                               // answer: rdlength 0
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -935,7 +933,7 @@ class ParserTest extends TestCase
         $data .= "00 01 51 80";                         // answer: ttl 86400
         $data .= "00 00";                               // answer: rdlength 0
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -947,7 +945,7 @@ class ParserTest extends TestCase
         $data .= "00 01 51 80";                         // answer: ttl 86400
         $data .= "00 00";                               // answer: rdlength 0
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -960,7 +958,7 @@ class ParserTest extends TestCase
         $data .= "00 06";                               // answer: rdlength 6
         $data .= "06 68 65 6c 6c 6f 6f";                // answer: rdata length 6: helloo
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -973,7 +971,7 @@ class ParserTest extends TestCase
         $data .= "00 08";                               // answer: rdlength 8
         $data .= "00 0a 05 68 65 6c 6c 6f";             // answer: rdata priority 10: hello (missing label end)
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -986,7 +984,7 @@ class ParserTest extends TestCase
         $data .= "00 02";                               // answer: rdlength 2
         $data .= "00 0a";                               // answer: rdata priority 10
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -999,7 +997,7 @@ class ParserTest extends TestCase
         $data .= "00 0b";                               // answer: rdlength 11
         $data .= "00 0a 00 14 1F 90 04 74 65 73 74";    // answer: rdata priority 10, weight 20, port 8080 test (missing label end)
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -1012,7 +1010,7 @@ class ParserTest extends TestCase
         $data .= "00 06";                               // answer: rdlength 6
         $data .= "00 0a 00 14 1F 90";                   // answer: rdata priority 10, weight 20, port 8080
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -1025,7 +1023,7 @@ class ParserTest extends TestCase
         $data .= "00 02";                               // answer: rdlength 2
         $data .= "01 01";                               // answer: algorithm 1 (RSA), type 1 (SHA), missing fingerprint
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -1038,7 +1036,7 @@ class ParserTest extends TestCase
         $data .= "00 03";                               // answer: rdlength 3
         $data .= "00 00 00";                            // answer: type 0, length incomplete
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -1051,7 +1049,7 @@ class ParserTest extends TestCase
         $data .= "00 07";                               // answer: rdlength 7
         $data .= "00 0b 00 03 01 02 03";                // answer: type OPT_TCP_KEEPALIVE, length 3 instead of 2
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -1065,7 +1063,7 @@ class ParserTest extends TestCase
         $data .= "02 6e 73 05 68 65 6c 6c 6f 00";       // answer: rdata ns.hello (mname)
         $data .= "01 65 05 68 65 6c 6c 6f 00";          // answer: rdata e.hello (rname)
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -1077,7 +1075,7 @@ class ParserTest extends TestCase
         $data .= "00 01 51 80";                         // answer: ttl 86400
         $data .= "00 00";                               // answer: rdlength 0
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -1090,7 +1088,7 @@ class ParserTest extends TestCase
         $data .= "00 07";                               // answer: rdlength 22
         $data .= "00 05 69 73 73 75 65";                // answer: rdata 0, issue
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 
@@ -1104,7 +1102,7 @@ class ParserTest extends TestCase
         $data .= "00 ff 69 73 73 75 65";                // answer: rdata 0, issue (incomplete due to invalid tag length)
         $data .= "68 65 6c 6c 6f";                      // answer: hello
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->parseAnswer($data);
     }
 

--- a/tests/Query/CoopExecutorTest.php
+++ b/tests/Query/CoopExecutorTest.php
@@ -59,8 +59,8 @@ class CoopExecutorTest extends TestCase
         $query2 = new Query('reactphp.org', Message::TYPE_AAAA, Message::CLASS_IN);
         $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
         $base->expects($this->exactly(2))->method('query')->withConsecutive(
-            array($query1),
-            array($query2)
+            [$query1],
+            [$query2]
         )->willReturn($pending);
         $connector = new CoopExecutor($base);
 

--- a/tests/Query/CoopExecutorTest.php
+++ b/tests/Query/CoopExecutorTest.php
@@ -1,11 +1,15 @@
 <?php
 
-use React\Dns\Query\CoopExecutor;
 use React\Dns\Model\Message;
+use React\Dns\Query\CoopExecutor;
+use React\Dns\Query\ExecutorInterface;
 use React\Dns\Query\Query;
-use React\Promise\Promise;
-use React\Tests\Dns\TestCase;
 use React\Promise\Deferred;
+use React\Promise\Promise;
+use React\Promise\PromiseInterface;
+use React\Tests\Dns\TestCase;
+use function React\Promise\reject;
+use function React\Promise\resolve;
 
 class CoopExecutorTest extends TestCase
 {
@@ -13,7 +17,7 @@ class CoopExecutorTest extends TestCase
     {
         $pending = new Promise(function () { });
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base = $this->createMock(ExecutorInterface::class);
         $base->expects($this->once())->method('query')->with($query)->willReturn($pending);
         $connector = new CoopExecutor($base);
 
@@ -24,14 +28,14 @@ class CoopExecutorTest extends TestCase
     {
         $message = new Message();
 
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $base->expects($this->once())->method('query')->willReturn(\React\Promise\resolve($message));
+        $base = $this->createMock(ExecutorInterface::class);
+        $base->expects($this->once())->method('query')->willReturn(resolve($message));
         $connector = new CoopExecutor($base);
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
         $promise = $connector->query($query);
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
 
         $promise->then($this->expectCallableOnceWith($message));
     }
@@ -40,14 +44,14 @@ class CoopExecutorTest extends TestCase
     {
         $exception = new RuntimeException();
 
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $base->expects($this->once())->method('query')->willReturn(\React\Promise\reject($exception));
+        $base = $this->createMock(ExecutorInterface::class);
+        $base->expects($this->once())->method('query')->willReturn(reject($exception));
         $connector = new CoopExecutor($base);
 
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
         $promise = $connector->query($query);
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
 
         $promise->then(null, $this->expectCallableOnceWith($exception));
     }
@@ -57,7 +61,7 @@ class CoopExecutorTest extends TestCase
         $pending = new Promise(function () { });
         $query1 = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
         $query2 = new Query('reactphp.org', Message::TYPE_AAAA, Message::CLASS_IN);
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base = $this->createMock(ExecutorInterface::class);
         $base->expects($this->exactly(2))->method('query')->withConsecutive(
             [$query1],
             [$query2]
@@ -72,7 +76,7 @@ class CoopExecutorTest extends TestCase
     {
         $pending = new Promise(function () { });
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base = $this->createMock(ExecutorInterface::class);
         $base->expects($this->once())->method('query')->with($query)->willReturn($pending);
         $connector = new CoopExecutor($base);
 
@@ -85,7 +89,7 @@ class CoopExecutorTest extends TestCase
         $deferred = new Deferred();
         $pending = new Promise(function () { });
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base = $this->createMock(ExecutorInterface::class);
         $base->expects($this->exactly(2))->method('query')->with($query)->willReturnOnConsecutiveCalls($deferred->promise(), $pending);
 
         $connector = new CoopExecutor($base);
@@ -102,7 +106,7 @@ class CoopExecutorTest extends TestCase
         $deferred = new Deferred();
         $pending = new Promise(function () { });
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base = $this->createMock(ExecutorInterface::class);
         $base->expects($this->exactly(2))->method('query')->with($query)->willReturnOnConsecutiveCalls($deferred->promise(), $pending);
 
         $connector = new CoopExecutor($base);
@@ -120,7 +124,7 @@ class CoopExecutorTest extends TestCase
     {
         $promise = new Promise(function () { }, $this->expectCallableOnce());
 
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base = $this->createMock(ExecutorInterface::class);
         $base->expects($this->once())->method('query')->willReturn($promise);
         $connector = new CoopExecutor($base);
 
@@ -135,7 +139,7 @@ class CoopExecutorTest extends TestCase
         });
 
         /** @var \RuntimeException $exception */
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('DNS query for reactphp.org (A) has been cancelled', $exception->getMessage());
     }
 
@@ -143,7 +147,7 @@ class CoopExecutorTest extends TestCase
     {
         $promise = new Promise(function () { }, $this->expectCallableNever());
 
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base = $this->createMock(ExecutorInterface::class);
         $base->expects($this->once())->method('query')->willReturn($promise);
         $connector = new CoopExecutor($base);
 
@@ -161,7 +165,7 @@ class CoopExecutorTest extends TestCase
     {
         $promise = new Promise(function () { }, $this->expectCallableNever());
 
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base = $this->createMock(ExecutorInterface::class);
         $base->expects($this->once())->method('query')->willReturn($promise);
         $connector = new CoopExecutor($base);
 
@@ -179,7 +183,7 @@ class CoopExecutorTest extends TestCase
     {
         $promise = new Promise(function () { }, $this->expectCallableOnce());
 
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base = $this->createMock(ExecutorInterface::class);
         $base->expects($this->once())->method('query')->willReturn($promise);
         $connector = new CoopExecutor($base);
 
@@ -199,7 +203,7 @@ class CoopExecutorTest extends TestCase
         $promise = new Promise(function () { }, $this->expectCallableOnce());
         $pending = new Promise(function () { });
 
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base = $this->createMock(ExecutorInterface::class);
         $base->expects($this->exactly(2))->method('query')->willReturnOnConsecutiveCalls($promise, $pending);
         $connector = new CoopExecutor($base);
 
@@ -225,7 +229,7 @@ class CoopExecutorTest extends TestCase
             throw new \RuntimeException();
         });
 
-        $base = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $base = $this->createMock(ExecutorInterface::class);
         $base->expects($this->once())->method('query')->willReturn($deferred->promise());
         $connector = new CoopExecutor($base);
 

--- a/tests/Query/FallbackExecutorTest.php
+++ b/tests/Query/FallbackExecutorTest.php
@@ -3,10 +3,14 @@
 namespace React\Tests\Dns\Query;
 
 use React\Dns\Model\Message;
+use React\Dns\Query\ExecutorInterface;
 use React\Dns\Query\FallbackExecutor;
 use React\Dns\Query\Query;
 use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 use React\Tests\Dns\TestCase;
+use function React\Promise\reject;
+use function React\Promise\resolve;
 
 class FallbackExecutorTest extends TestCase
 {
@@ -14,16 +18,16 @@ class FallbackExecutorTest extends TestCase
     {
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary = $this->createMock(ExecutorInterface::class);
         $primary->expects($this->once())->method('query')->with($query)->willReturn(new Promise(function () { }));
 
-        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary = $this->createMock(ExecutorInterface::class);
 
         $executor = new FallbackExecutor($primary, $secondary);
 
         $promise = $executor->query($query);
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
     }
 
@@ -31,34 +35,34 @@ class FallbackExecutorTest extends TestCase
     {
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\resolve(new Message()));
+        $primary = $this->createMock(ExecutorInterface::class);
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(resolve(new Message()));
 
-        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary = $this->createMock(ExecutorInterface::class);
 
         $executor = new FallbackExecutor($primary, $secondary);
 
         $promise = $executor->query($query);
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
-        $promise->then($this->expectCallableOnceWith($this->isInstanceOf('React\Dns\Model\Message')), $this->expectCallableNever());
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+        $promise->then($this->expectCallableOnceWith($this->isInstanceOf(Message::class)), $this->expectCallableNever());
     }
 
     public function testQueryWillReturnPendingPromiseWhenPrimaryExecutorRejectsPromiseAndSecondaryExecutorIsStillPending()
     {
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException()));
+        $primary = $this->createMock(ExecutorInterface::class);
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(reject(new \RuntimeException()));
 
-        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary = $this->createMock(ExecutorInterface::class);
         $secondary->expects($this->once())->method('query')->with($query)->willReturn(new Promise(function () { }));
 
         $executor = new FallbackExecutor($primary, $secondary);
 
         $promise = $executor->query($query);
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
     }
 
@@ -66,43 +70,43 @@ class FallbackExecutorTest extends TestCase
     {
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException()));
+        $primary = $this->createMock(ExecutorInterface::class);
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(reject(new \RuntimeException()));
 
-        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $secondary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\resolve(new Message()));
+        $secondary = $this->createMock(ExecutorInterface::class);
+        $secondary->expects($this->once())->method('query')->with($query)->willReturn(resolve(new Message()));
 
         $executor = new FallbackExecutor($primary, $secondary);
 
         $promise = $executor->query($query);
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
-        $promise->then($this->expectCallableOnceWith($this->isInstanceOf('React\Dns\Model\Message')), $this->expectCallableNever());
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+        $promise->then($this->expectCallableOnceWith($this->isInstanceOf(Message::class)), $this->expectCallableNever());
     }
 
     public function testQueryWillRejectWithExceptionMessagesConcatenatedAfterColonWhenPrimaryExecutorRejectsPromiseAndSecondaryExecutorRejectsPromiseWithMessageWithColon()
     {
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException('DNS query for reactphp.org (A) failed: Unable to connect to DNS server A')));
+        $primary = $this->createMock(ExecutorInterface::class);
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(reject(new \RuntimeException('DNS query for reactphp.org (A) failed: Unable to connect to DNS server A')));
 
-        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $secondary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException('DNS query for reactphp.org (A) failed: Unable to connect to DNS server B')));
+        $secondary = $this->createMock(ExecutorInterface::class);
+        $secondary->expects($this->once())->method('query')->with($query)->willReturn(reject(new \RuntimeException('DNS query for reactphp.org (A) failed: Unable to connect to DNS server B')));
 
         $executor = new FallbackExecutor($primary, $secondary);
 
         $promise = $executor->query($query);
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
-        $promise->then($this->expectCallableNever(), $this->expectCallableOnce($this->isInstanceOf('Exception')));
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce($this->isInstanceOf(\Exception::class)));
 
         $exception = null;
         $promise->then(null, function ($reason) use (&$exception) {
             $exception = $reason;
         });
 
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('DNS query for reactphp.org (A) failed: Unable to connect to DNS server A. Unable to connect to DNS server B', $exception->getMessage());
     }
 
@@ -110,25 +114,25 @@ class FallbackExecutorTest extends TestCase
     {
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException('Reason A')));
+        $primary = $this->createMock(ExecutorInterface::class);
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(reject(new \RuntimeException('Reason A')));
 
-        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $secondary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException('Reason B')));
+        $secondary = $this->createMock(ExecutorInterface::class);
+        $secondary->expects($this->once())->method('query')->with($query)->willReturn(reject(new \RuntimeException('Reason B')));
 
         $executor = new FallbackExecutor($primary, $secondary);
 
         $promise = $executor->query($query);
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
-        $promise->then($this->expectCallableNever(), $this->expectCallableOnce($this->isInstanceOf('Exception')));
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce($this->isInstanceOf(\Exception::class)));
 
         $exception = null;
         $promise->then(null, function ($reason) use (&$exception) {
             $exception = $reason;
         });
 
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('Reason A. Reason B', $exception->getMessage());
     }
 
@@ -136,10 +140,10 @@ class FallbackExecutorTest extends TestCase
     {
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary = $this->createMock(ExecutorInterface::class);
         $primary->expects($this->once())->method('query')->with($query)->willReturn(new Promise(function () { }, function () { throw new \RuntimeException(); }));
 
-        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary = $this->createMock(ExecutorInterface::class);
         $secondary->expects($this->never())->method('query');
 
         $executor = new FallbackExecutor($primary, $secondary);
@@ -147,7 +151,7 @@ class FallbackExecutorTest extends TestCase
         $promise = $executor->query($query);
         $promise->cancel();
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
     }
 
@@ -155,10 +159,10 @@ class FallbackExecutorTest extends TestCase
     {
         $query = new Query('reactphp.org', Message::TYPE_A, Message::CLASS_IN);
 
-        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $primary->expects($this->once())->method('query')->with($query)->willReturn(\React\Promise\reject(new \RuntimeException()));
+        $primary = $this->createMock(ExecutorInterface::class);
+        $primary->expects($this->once())->method('query')->with($query)->willReturn(reject(new \RuntimeException()));
 
-        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary = $this->createMock(ExecutorInterface::class);
         $secondary->expects($this->once())->method('query')->with($query)->willReturn(new Promise(function () { }, function () { throw new \RuntimeException(); }));
 
         $executor = new FallbackExecutor($primary, $secondary);
@@ -166,7 +170,7 @@ class FallbackExecutorTest extends TestCase
         $promise = $executor->query($query);
         $promise->cancel();
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
     }
 
@@ -176,10 +180,10 @@ class FallbackExecutorTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $primary = $this->createMock(ExecutorInterface::class);
         $primary->expects($this->once())->method('query')->willReturn(new Promise(function () { }, function () { throw new \RuntimeException(); }));
 
-        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary = $this->createMock(ExecutorInterface::class);
         $secondary->expects($this->never())->method('query');
 
         $executor = new FallbackExecutor($primary, $secondary);
@@ -203,10 +207,10 @@ class FallbackExecutorTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $primary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $primary->expects($this->once())->method('query')->willReturn(\React\Promise\reject(new \RuntimeException()));
+        $primary = $this->createMock(ExecutorInterface::class);
+        $primary->expects($this->once())->method('query')->willReturn(reject(new \RuntimeException()));
 
-        $secondary = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $secondary = $this->createMock(ExecutorInterface::class);
         $secondary->expects($this->once())->method('query')->willReturn(new Promise(function () { }, function () { throw new \RuntimeException(); }));
 
         $executor = new FallbackExecutor($primary, $secondary);

--- a/tests/Query/HostsFileExecutorTest.php
+++ b/tests/Query/HostsFileExecutorTest.php
@@ -33,7 +33,7 @@ class HostsFileExecutorTest extends TestCase
 
     public function testFallsBackIfNoIpsWereFound()
     {
-        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array());
+        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn([]);
         $this->fallback->expects($this->once())->method('query');
 
         $this->executor->query(new Query('google.com', Message::TYPE_A, Message::CLASS_IN));
@@ -41,7 +41,7 @@ class HostsFileExecutorTest extends TestCase
 
     public function testReturnsResponseMessageIfIpsWereFound()
     {
-        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('127.0.0.1'));
+        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(['127.0.0.1']);
         $this->fallback->expects($this->never())->method('query');
 
         $ret = $this->executor->query(new Query('google.com', Message::TYPE_A, Message::CLASS_IN));
@@ -49,7 +49,7 @@ class HostsFileExecutorTest extends TestCase
 
     public function testFallsBackIfNoIpv4Matches()
     {
-        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('::1'));
+        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(['::1']);
         $this->fallback->expects($this->once())->method('query');
 
         $ret = $this->executor->query(new Query('google.com', Message::TYPE_A, Message::CLASS_IN));
@@ -57,7 +57,7 @@ class HostsFileExecutorTest extends TestCase
 
     public function testReturnsResponseMessageIfIpv6AddressesWereFound()
     {
-        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('::1'));
+        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(['::1']);
         $this->fallback->expects($this->never())->method('query');
 
         $ret = $this->executor->query(new Query('google.com', Message::TYPE_AAAA, Message::CLASS_IN));
@@ -65,7 +65,7 @@ class HostsFileExecutorTest extends TestCase
 
     public function testFallsBackIfNoIpv6Matches()
     {
-        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(array('127.0.0.1'));
+        $this->hosts->expects($this->once())->method('getIpsForHost')->willReturn(['127.0.0.1']);
         $this->fallback->expects($this->once())->method('query');
 
         $ret = $this->executor->query(new Query('google.com', Message::TYPE_AAAA, Message::CLASS_IN));
@@ -73,7 +73,7 @@ class HostsFileExecutorTest extends TestCase
 
     public function testDoesReturnReverseIpv4Lookup()
     {
-        $this->hosts->expects($this->once())->method('getHostsForIp')->with('127.0.0.1')->willReturn(array('localhost'));
+        $this->hosts->expects($this->once())->method('getHostsForIp')->with('127.0.0.1')->willReturn(['localhost']);
         $this->fallback->expects($this->never())->method('query');
 
         $this->executor->query(new Query('1.0.0.127.in-addr.arpa', Message::TYPE_PTR, Message::CLASS_IN));
@@ -81,7 +81,7 @@ class HostsFileExecutorTest extends TestCase
 
     public function testFallsBackIfNoReverseIpv4Matches()
     {
-        $this->hosts->expects($this->once())->method('getHostsForIp')->with('127.0.0.1')->willReturn(array());
+        $this->hosts->expects($this->once())->method('getHostsForIp')->with('127.0.0.1')->willReturn([]);
         $this->fallback->expects($this->once())->method('query');
 
         $this->executor->query(new Query('1.0.0.127.in-addr.arpa', Message::TYPE_PTR, Message::CLASS_IN));
@@ -89,7 +89,7 @@ class HostsFileExecutorTest extends TestCase
 
     public function testDoesReturnReverseIpv6Lookup()
     {
-        $this->hosts->expects($this->once())->method('getHostsForIp')->with('2a02:2e0:3fe:100::6')->willReturn(array('ip6-localhost'));
+        $this->hosts->expects($this->once())->method('getHostsForIp')->with('2a02:2e0:3fe:100::6')->willReturn(['ip6-localhost']);
         $this->fallback->expects($this->never())->method('query');
 
         $this->executor->query(new Query('6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.e.f.3.0.0.e.2.0.2.0.a.2.ip6.arpa', Message::TYPE_PTR, Message::CLASS_IN));

--- a/tests/Query/HostsFileExecutorTest.php
+++ b/tests/Query/HostsFileExecutorTest.php
@@ -2,10 +2,12 @@
 
 namespace React\Tests\Dns\Query;
 
-use React\Tests\Dns\TestCase;
+use React\Dns\Config\HostsFile;
+use React\Dns\Model\Message;
+use React\Dns\Query\ExecutorInterface;
 use React\Dns\Query\HostsFileExecutor;
 use React\Dns\Query\Query;
-use React\Dns\Model\Message;
+use React\Tests\Dns\TestCase;
 
 class HostsFileExecutorTest extends TestCase
 {
@@ -18,8 +20,8 @@ class HostsFileExecutorTest extends TestCase
      */
     public function setUpMocks()
     {
-        $this->hosts = $this->getMockBuilder('React\Dns\Config\HostsFile')->disableOriginalConstructor()->getMock();
-        $this->fallback = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $this->hosts = $this->createMock(HostsFile::class);
+        $this->fallback = $this->createMock(ExecutorInterface::class);
         $this->executor = new HostsFileExecutor($this->hosts, $this->fallback);
     }
 

--- a/tests/Query/RetryExecutorTest.php
+++ b/tests/Query/RetryExecutorTest.php
@@ -8,9 +8,10 @@ use React\Dns\Query\Query;
 use React\Dns\Model\Message;
 use React\Dns\Query\TimeoutException;
 use React\Dns\Model\Record;
-use React\Promise;
 use React\Promise\Deferred;
 use React\Dns\Query\CancellationException;
+use function React\Promise\reject;
+use function React\Promise\resolve;
 
 class RetryExecutorTest extends TestCase
 {
@@ -48,10 +49,10 @@ class RetryExecutorTest extends TestCase
             ->with($this->isInstanceOf('React\Dns\Query\Query'))
             ->will($this->onConsecutiveCalls(
                 $this->returnCallback(function ($query) {
-                    return Promise\reject(new TimeoutException("timeout"));
+                    return reject(new TimeoutException("timeout"));
                 }),
                 $this->returnCallback(function ($query) use ($response) {
-                    return Promise\resolve($response);
+                    return resolve($response);
                 })
             ));
 
@@ -81,7 +82,7 @@ class RetryExecutorTest extends TestCase
             ->method('query')
             ->with($this->isInstanceOf('React\Dns\Query\Query'))
             ->will($this->returnCallback(function ($query) {
-                return Promise\reject(new TimeoutException("timeout"));
+                return reject(new TimeoutException("timeout"));
             }));
 
         $retryExecutor = new RetryExecutor($executor, 2);
@@ -114,7 +115,7 @@ class RetryExecutorTest extends TestCase
             ->method('query')
             ->with($this->isInstanceOf('React\Dns\Query\Query'))
             ->will($this->returnCallback(function ($query) {
-                return Promise\reject(new \Exception);
+                return reject(new \Exception);
             }));
 
         $callback = $this->expectCallableNever();
@@ -222,7 +223,7 @@ class RetryExecutorTest extends TestCase
             ->expects($this->once())
             ->method('query')
             ->with($this->isInstanceOf('React\Dns\Query\Query'))
-            ->willReturn(Promise\resolve($this->createStandardResponse()));
+            ->willReturn(resolve($this->createStandardResponse()));
 
         $retryExecutor = new RetryExecutor($executor, 0);
 
@@ -251,7 +252,7 @@ class RetryExecutorTest extends TestCase
             ->expects($this->any())
             ->method('query')
             ->with($this->isInstanceOf('React\Dns\Query\Query'))
-            ->willReturn(Promise\reject(new TimeoutException("timeout")));
+            ->willReturn(reject(new TimeoutException("timeout")));
 
         $retryExecutor = new RetryExecutor($executor, 0);
 
@@ -318,7 +319,7 @@ class RetryExecutorTest extends TestCase
             ->method('query')
             ->with($this->isInstanceOf('React\Dns\Query\Query'))
             ->will($this->returnCallback(function ($query) {
-                return Promise\reject(new \Exception);
+                return reject(new \Exception);
             }));
 
         $retryExecutor = new RetryExecutor($executor, 2);
@@ -341,7 +342,7 @@ class RetryExecutorTest extends TestCase
         $mock
             ->expects($this->once())
             ->method('then')
-            ->will($this->returnValue(Promise\resolve($return)));
+            ->will($this->returnValue(resolve($return)));
 
         return $mock;
     }

--- a/tests/Query/SelectiveTransportExecutorTest.php
+++ b/tests/Query/SelectiveTransportExecutorTest.php
@@ -3,11 +3,14 @@
 namespace React\Tests\Dns\Query;
 
 use React\Dns\Model\Message;
+use React\Dns\Query\ExecutorInterface;
 use React\Dns\Query\Query;
 use React\Dns\Query\SelectiveTransportExecutor;
 use React\Promise\Deferred;
 use React\Promise\Promise;
 use React\Tests\Dns\TestCase;
+use function React\Promise\reject;
+use function React\Promise\resolve;
 
 class SelectiveTransportExecutorTest extends TestCase
 {
@@ -20,8 +23,8 @@ class SelectiveTransportExecutorTest extends TestCase
      */
     public function setUpMocks()
     {
-        $this->datagram = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
-        $this->stream = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $this->datagram = $this->createMock(ExecutorInterface::class);
+        $this->stream = $this->createMock(ExecutorInterface::class);
 
         $this->executor = new SelectiveTransportExecutor($this->datagram, $this->stream);
     }
@@ -36,7 +39,7 @@ class SelectiveTransportExecutorTest extends TestCase
             ->expects($this->once())
             ->method('query')
             ->with($query)
-            ->willReturn(\React\Promise\resolve($response));
+            ->willReturn(resolve($response));
 
         $this->stream
             ->expects($this->never())
@@ -57,13 +60,13 @@ class SelectiveTransportExecutorTest extends TestCase
             ->expects($this->once())
             ->method('query')
             ->with($query)
-            ->willReturn(\React\Promise\reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90)));
+            ->willReturn(reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90)));
 
         $this->stream
             ->expects($this->once())
             ->method('query')
             ->with($query)
-            ->willReturn(\React\Promise\resolve($response));
+            ->willReturn(resolve($response));
 
         $promise = $this->executor->query($query);
 
@@ -78,7 +81,7 @@ class SelectiveTransportExecutorTest extends TestCase
             ->expects($this->once())
             ->method('query')
             ->with($query)
-            ->willReturn(\React\Promise\reject(new \RuntimeException()));
+            ->willReturn(reject(new \RuntimeException()));
 
         $this->stream
             ->expects($this->never())
@@ -97,13 +100,13 @@ class SelectiveTransportExecutorTest extends TestCase
             ->expects($this->once())
             ->method('query')
             ->with($query)
-            ->willReturn(\React\Promise\reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90)));
+            ->willReturn(reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90)));
 
         $this->stream
             ->expects($this->once())
             ->method('query')
             ->with($query)
-            ->willReturn(\React\Promise\reject(new \RuntimeException()));
+            ->willReturn(reject(new \RuntimeException()));
 
         $promise = $this->executor->query($query);
 
@@ -216,13 +219,13 @@ class SelectiveTransportExecutorTest extends TestCase
             ->expects($this->once())
             ->method('query')
             ->with($query)
-            ->willReturn(\React\Promise\reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90)));
+            ->willReturn(reject(new \RuntimeException('', defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90)));
 
         $this->stream
             ->expects($this->once())
             ->method('query')
             ->with($query)
-            ->willReturn(\React\Promise\reject(new \RuntimeException()));
+            ->willReturn(reject(new \RuntimeException()));
 
         while (gc_collect_cycles()) {
             // collect all garbage cycles

--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -117,10 +117,6 @@ class TcpTransportExecutorTest extends TestCase
 
     public function testQueryRejectsIfServerConnectionFails()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('HHVM reports different error message for invalid addresses');
-        }
-
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->never())->method('addWriteStream');
 
@@ -403,11 +399,11 @@ class TcpTransportExecutorTest extends TestCase
         restore_error_handler();
         $this->assertNull($error);
 
-        // expect EPIPE (Broken pipe), except for macOS kernel race condition or legacy HHVM
+        // expect EPIPE (Broken pipe), except for macOS kernel race condition
         $this->setExpectedException(
             'RuntimeException',
             'Unable to send query to DNS server tcp://' . $address . ' (',
-            defined('SOCKET_EPIPE') && !defined('HHVM_VERSION') ? (PHP_OS !== 'Darwin' || $writePending ? SOCKET_EPIPE : SOCKET_EPROTOTYPE) : null
+            defined('SOCKET_EPIPE') ? (PHP_OS !== 'Darwin' || $writePending ? SOCKET_EPIPE : SOCKET_EPROTOTYPE) : null
         );
         throw $exception;
     }

--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -32,32 +32,32 @@ class TcpTransportExecutorTest extends TestCase
 
     public static function provideDefaultPortProvider()
     {
-        return array(
-            array(
+        return [
+            [
                 '8.8.8.8',
                 'tcp://8.8.8.8:53'
-            ),
-            array(
+            ],
+            [
                 '1.2.3.4:5',
                 'tcp://1.2.3.4:5'
-            ),
-            array(
+            ],
+            [
                 'tcp://1.2.3.4',
                 'tcp://1.2.3.4:53'
-            ),
-            array(
+            ],
+            [
                 'tcp://1.2.3.4:53',
                 'tcp://1.2.3.4:53'
-            ),
-            array(
+            ],
+            [
                 '::1',
                 'tcp://[::1]:53'
-            ),
-            array(
+            ],
+            [
                 '[::1]:53',
                 'tcp://[::1]:53'
-            )
-        );
+            ]
+        ];
     }
 
     public function testCtorWithoutLoopShouldAssignDefaultLoop()

--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -5,10 +5,17 @@ namespace React\Tests\Dns\Query;
 use React\Dns\Model\Message;
 use React\Dns\Protocol\BinaryDumper;
 use React\Dns\Protocol\Parser;
+use React\Dns\Query\CancellationException;
 use React\Dns\Query\Query;
 use React\Dns\Query\TcpTransportExecutor;
 use React\EventLoop\Loop;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
+use React\Promise\PromiseInterface;
 use React\Tests\Dns\TestCase;
+use function React\Async\await;
+use function React\Promise\Timer\sleep;
+use function React\Promise\Timer\timeout;
 
 class TcpTransportExecutorTest extends TestCase
 {
@@ -19,7 +26,7 @@ class TcpTransportExecutorTest extends TestCase
      */
     public function testCtorShouldAcceptNameserverAddresses($input, $expected)
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
 
         $executor = new TcpTransportExecutor($input, $loop);
 
@@ -32,31 +39,29 @@ class TcpTransportExecutorTest extends TestCase
 
     public static function provideDefaultPortProvider()
     {
-        return [
-            [
-                '8.8.8.8',
-                'tcp://8.8.8.8:53'
-            ],
-            [
-                '1.2.3.4:5',
-                'tcp://1.2.3.4:5'
-            ],
-            [
-                'tcp://1.2.3.4',
-                'tcp://1.2.3.4:53'
-            ],
-            [
-                'tcp://1.2.3.4:53',
-                'tcp://1.2.3.4:53'
-            ],
-            [
-                '::1',
-                'tcp://[::1]:53'
-            ],
-            [
-                '[::1]:53',
-                'tcp://[::1]:53'
-            ]
+        yield [
+            '8.8.8.8',
+            'tcp://8.8.8.8:53'
+        ];
+        yield [
+            '1.2.3.4:5',
+            'tcp://1.2.3.4:5'
+        ];
+        yield [
+            'tcp://1.2.3.4',
+            'tcp://1.2.3.4:53'
+        ];
+        yield [
+            'tcp://1.2.3.4:53',
+            'tcp://1.2.3.4:53'
+        ];
+        yield [
+            '::1',
+            'tcp://[::1]:53'
+        ];
+        yield [
+            '[::1]:53',
+            'tcp://[::1]:53'
         ];
     }
 
@@ -68,36 +73,36 @@ class TcpTransportExecutorTest extends TestCase
         $ref->setAccessible(true);
         $loop = $ref->getValue($executor);
 
-        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+        $this->assertInstanceOf(LoopInterface::class, $loop);
     }
 
     public function testCtorShouldThrowWhenNameserverAddressIsInvalid()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new TcpTransportExecutor('///', $loop);
     }
 
     public function testCtorShouldThrowWhenNameserverAddressContainsHostname()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new TcpTransportExecutor('localhost', $loop);
     }
 
     public function testCtorShouldThrowWhenNameserverSchemeIsInvalid()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new TcpTransportExecutor('udp://1.2.3.4', $loop);
     }
 
     public function testQueryRejectsIfMessageExceedsMaximumMessageSize()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->never())->method('addWriteStream');
 
         $executor = new TcpTransportExecutor('8.8.8.8:53', $loop);
@@ -111,13 +116,13 @@ class TcpTransportExecutorTest extends TestCase
         });
 
         /** @var \RuntimeException $exception */
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('DNS query for '. $query->name . ' (A) failed: Query too large for TCP transport', $exception->getMessage());
     }
 
     public function testQueryRejectsIfServerConnectionFails()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->never())->method('addWriteStream');
 
         $executor = new TcpTransportExecutor('::1', $loop);
@@ -135,19 +140,19 @@ class TcpTransportExecutorTest extends TestCase
         });
 
         /** @var \RuntimeException $exception */
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('DNS query for google.com (A) failed: Unable to connect to DNS server /// (Failed to parse address "///")', $exception->getMessage());
     }
 
     public function testQueryRejectsOnCancellationWithoutClosingSocketButStartsIdleTimer()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->never())->method('removeWriteStream');
         $loop->expects($this->never())->method('addReadStream');
         $loop->expects($this->never())->method('removeReadStream');
 
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
         $loop->expects($this->once())->method('addTimer')->with(0.001, $this->anything())->willReturn($timer);
         $loop->expects($this->never())->method('cancelTimer');
 
@@ -166,19 +171,19 @@ class TcpTransportExecutorTest extends TestCase
         });
 
         /** @var \React\Dns\Query\CancellationException $exception */
-        $this->assertInstanceOf('React\Dns\Query\CancellationException', $exception);
+        $this->assertInstanceOf(CancellationException::class, $exception);
         $this->assertEquals('DNS query for google.com (A) has been cancelled', $exception->getMessage());
     }
 
     public function testTriggerIdleTimerAfterQueryRejectedOnCancellationWillCloseSocket()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->once())->method('removeWriteStream');
         $loop->expects($this->never())->method('addReadStream');
         $loop->expects($this->never())->method('removeReadStream');
 
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
         $timerCallback = null;
         $loop->expects($this->once())->method('addTimer')->with(0.001, $this->callback(function ($cb) use (&$timerCallback) {
             $timerCallback = $cb;
@@ -195,7 +200,7 @@ class TcpTransportExecutorTest extends TestCase
         $promise = $executor->query($query);
         $promise->cancel();
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
         $promise->then(null, $this->expectCallableOnce());
 
         // trigger idle timer
@@ -205,7 +210,7 @@ class TcpTransportExecutorTest extends TestCase
 
     public function testQueryRejectsOnCancellationWithoutClosingSocketAndWithoutStartingIdleTimerWhenOtherQueryIsStillPending()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->never())->method('removeWriteStream');
         $loop->expects($this->never())->method('addReadStream');
@@ -230,7 +235,7 @@ class TcpTransportExecutorTest extends TestCase
 
     public function testQueryAgainAfterPreviousWasCancelledReusesExistingSocket()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->never())->method('removeWriteStream');
         $loop->expects($this->never())->method('addReadStream');
@@ -262,20 +267,20 @@ class TcpTransportExecutorTest extends TestCase
             }
         );
 
-        \React\Async\await(\React\Promise\Timer\sleep(0.01));
+        await(sleep(0.01));
         if ($exception === null) {
-            \React\Async\await(\React\Promise\Timer\sleep(0.2));
+            await(sleep(0.2));
         }
 
         /** @var \RuntimeException $exception */
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('DNS query for google.com (A) failed: Unable to connect to DNS server tcp://127.0.0.1:1 (Connection refused)', $exception->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $exception->getCode());
     }
 
     public function testQueryStaysPendingWhenClientCanNotSendExcessiveMessageInOneChunk()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->once())->method('addReadStream');
         $loop->expects($this->never())->method('removeWriteStream');
@@ -318,7 +323,7 @@ class TcpTransportExecutorTest extends TestCase
             $this->markTestSkipped('Skipped on macOS due to possible race condition');
         }
 
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->once())->method('addReadStream');
         $loop->expects($this->never())->method('removeWriteStream');
@@ -352,7 +357,7 @@ class TcpTransportExecutorTest extends TestCase
 
     public function testQueryRejectsWhenClientKeepsSendingWhenServerClosesSocketWithoutCallingCustomErrorHandler()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->once())->method('addReadStream');
         $loop->expects($this->once())->method('removeWriteStream');
@@ -400,8 +405,8 @@ class TcpTransportExecutorTest extends TestCase
         $this->assertNull($error);
 
         // expect EPIPE (Broken pipe), except for macOS kernel race condition
-        $this->setExpectedException(
-            'RuntimeException',
+        $this->expectException(
+            \RuntimeException::class,
             'Unable to send query to DNS server tcp://' . $address . ' (',
             defined('SOCKET_EPIPE') ? (PHP_OS !== 'Darwin' || $writePending ? SOCKET_EPIPE : SOCKET_EPROTOTYPE) : null
         );
@@ -432,13 +437,13 @@ class TcpTransportExecutorTest extends TestCase
             }
         );
 
-        \React\Async\await(\React\Promise\Timer\sleep(0.01));
+        await(sleep(0.01));
         if ($exception === null) {
-            \React\Async\await(\React\Promise\Timer\sleep(0.2));
+            await(sleep(0.2));
         }
 
         /** @var \RuntimeException $exception */
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('DNS query for google.com (A) failed: Connection to DNS server tcp://' . $address . ' lost', $exception->getMessage());
     }
 
@@ -470,7 +475,7 @@ class TcpTransportExecutorTest extends TestCase
             }
         );
 
-        \React\Async\await(\React\Promise\Timer\sleep(0.2));
+        await(sleep(0.2));
         $this->assertTrue($wait);
 
         $this->assertNotNull($client);
@@ -506,7 +511,7 @@ class TcpTransportExecutorTest extends TestCase
             }
         );
 
-        \React\Async\await(\React\Promise\Timer\sleep(0.2));
+        await(sleep(0.2));
         $this->assertTrue($wait);
 
         $this->assertNotNull($client);
@@ -541,13 +546,13 @@ class TcpTransportExecutorTest extends TestCase
             }
         );
 
-        \React\Async\await(\React\Promise\Timer\sleep(0.01));
+        await(sleep(0.01));
         if ($exception === null) {
-            \React\Async\await(\React\Promise\Timer\sleep(0.2));
+            await(sleep(0.2));
         }
 
         /** @var \RuntimeException $exception */
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('DNS query for google.com (A) failed: Invalid message received from DNS server tcp://' . $address, $exception->getMessage());
     }
 
@@ -593,13 +598,13 @@ class TcpTransportExecutorTest extends TestCase
             }
         );
 
-        \React\Async\await(\React\Promise\Timer\sleep(0.01));
+        await(sleep(0.01));
         if ($exception === null) {
-            \React\Async\await(\React\Promise\Timer\sleep(0.2));
+            await(sleep(0.2));
         }
 
         /** @var \RuntimeException $exception */
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('DNS query for google.com (A) failed: Invalid response message received from DNS server tcp://' . $address, $exception->getMessage());
     }
 
@@ -645,13 +650,13 @@ class TcpTransportExecutorTest extends TestCase
             }
         );
 
-        \React\Async\await(\React\Promise\Timer\sleep(0.01));
+        await(sleep(0.01));
         if ($exception === null) {
-            \React\Async\await(\React\Promise\Timer\sleep(0.2));
+            await(sleep(0.2));
         }
 
         /** @var \RuntimeException $exception */
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('DNS query for google.com (A) failed: Invalid response message received from DNS server tcp://' . $address, $exception->getMessage());
     }
 
@@ -680,14 +685,14 @@ class TcpTransportExecutorTest extends TestCase
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
 
         $promise = $executor->query($query);
-        $response = \React\Async\await(\React\Promise\Timer\timeout($promise, 0.2));
+        $response = await(timeout($promise, 0.2));
 
-        $this->assertInstanceOf('React\Dns\Model\Message', $response);
+        $this->assertInstanceOf(Message::class, $response);
     }
 
     public function testQueryRejectsIfSocketIsClosedAfterPreviousQueryThatWasStillPending()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->exactly(2))->method('addWriteStream');
         $loop->expects($this->exactly(2))->method('removeWriteStream');
         $loop->expects($this->once())->method('addReadStream');
@@ -721,7 +726,7 @@ class TcpTransportExecutorTest extends TestCase
 
     public function testQueryResolvesIfServerSendsBackResponseMessageAndWillStartIdleTimer()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->once())->method('removeWriteStream');
         $loop->expects($this->once())->method('addReadStream');
@@ -754,13 +759,13 @@ class TcpTransportExecutorTest extends TestCase
 
     public function testQueryResolvesIfServerSendsBackResponseMessageAfterCancellingQueryAndWillStartIdleTimer()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->once())->method('removeWriteStream');
         $loop->expects($this->once())->method('addReadStream');
         $loop->expects($this->never())->method('removeReadStream');
 
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
         $loop->expects($this->once())->method('addTimer')->with(0.001, $this->anything())->willReturn($timer);
         $loop->expects($this->never())->method('cancelTimer');
 
@@ -789,7 +794,7 @@ class TcpTransportExecutorTest extends TestCase
 
     public function testQueryResolvesIfServerSendsBackResponseMessageAfterCancellingOtherQueryAndWillStartIdleTimer()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->once())->method('removeWriteStream');
         $loop->expects($this->once())->method('addReadStream');
@@ -825,13 +830,13 @@ class TcpTransportExecutorTest extends TestCase
 
     public function testTriggerIdleTimerAfterPreviousQueryResolvedWillCloseIdleSocketConnection()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->once())->method('removeWriteStream');
         $loop->expects($this->once())->method('addReadStream');
         $loop->expects($this->once())->method('removeReadStream');
 
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
         $timerCallback = null;
         $loop->expects($this->once())->method('addTimer')->with(0.001, $this->callback(function ($cb) use (&$timerCallback) {
             $timerCallback = $cb;
@@ -867,13 +872,13 @@ class TcpTransportExecutorTest extends TestCase
 
     public function testClosingConnectionAfterPreviousQueryResolvedWillCancelIdleTimer()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addWriteStream');
         $loop->expects($this->once())->method('removeWriteStream');
         $loop->expects($this->once())->method('addReadStream');
         $loop->expects($this->once())->method('removeReadStream');
 
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
         $loop->expects($this->once())->method('addTimer')->with(0.001, $this->anything())->willReturn($timer);
         $loop->expects($this->once())->method('cancelTimer')->with($timer);
 
@@ -905,13 +910,13 @@ class TcpTransportExecutorTest extends TestCase
 
     public function testQueryAgainAfterPreviousQueryResolvedWillReuseSocketAndCancelIdleTimer()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->exactly(2))->method('addWriteStream');
         $loop->expects($this->once())->method('removeWriteStream');
         $loop->expects($this->once())->method('addReadStream');
         $loop->expects($this->never())->method('removeReadStream');
 
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
         $loop->expects($this->once())->method('addTimer')->with(0.001, $this->anything())->willReturn($timer);
         $loop->expects($this->once())->method('cancelTimer')->with($timer);
 

--- a/tests/Query/TimeoutExecutorTest.php
+++ b/tests/Query/TimeoutExecutorTest.php
@@ -7,9 +7,10 @@ use React\Dns\Query\CancellationException;
 use React\Dns\Query\Query;
 use React\Dns\Query\TimeoutException;
 use React\Dns\Query\TimeoutExecutor;
-use React\Promise;
 use React\Promise\Deferred;
 use React\Tests\Dns\TestCase;
+use function React\Promise\reject;
+use function React\Promise\resolve;
 
 class TimeoutExecutorTest extends TestCase
 {
@@ -78,7 +79,7 @@ class TimeoutExecutorTest extends TestCase
         $this->wrapped
             ->expects($this->once())
             ->method('query')
-            ->willReturn(Promise\resolve('0.0.0.0'));
+            ->willReturn(resolve('0.0.0.0'));
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
         $promise = $this->executor->query($query);
@@ -114,7 +115,7 @@ class TimeoutExecutorTest extends TestCase
         $this->wrapped
             ->expects($this->once())
             ->method('query')
-            ->willReturn(Promise\reject(new \RuntimeException()));
+            ->willReturn(reject(new \RuntimeException()));
 
         $query = new Query('igor.io', Message::TYPE_A, Message::CLASS_IN);
         $promise = $this->executor->query($query);

--- a/tests/Query/TimeoutExecutorTest.php
+++ b/tests/Query/TimeoutExecutorTest.php
@@ -4,9 +4,12 @@ namespace React\Tests\Dns\Query;
 
 use React\Dns\Model\Message;
 use React\Dns\Query\CancellationException;
+use React\Dns\Query\ExecutorInterface;
 use React\Dns\Query\Query;
 use React\Dns\Query\TimeoutException;
 use React\Dns\Query\TimeoutExecutor;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
 use React\Promise\Deferred;
 use React\Tests\Dns\TestCase;
 use function React\Promise\reject;
@@ -23,9 +26,9 @@ class TimeoutExecutorTest extends TestCase
      */
     public function setUpExecutor()
     {
-        $this->wrapped = $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        $this->wrapped = $this->createMock(ExecutorInterface::class);
 
-        $this->loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $this->loop = $this->createMock(LoopInterface::class);
 
         $this->executor = new TimeoutExecutor($this->wrapped, 5.0, $this->loop);
     }
@@ -38,12 +41,12 @@ class TimeoutExecutorTest extends TestCase
         $ref->setAccessible(true);
         $loop = $ref->getValue($executor);
 
-        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+        $this->assertInstanceOf(LoopInterface::class, $loop);
     }
 
     public function testCancellingPromiseWillCancelWrapped()
     {
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
         $this->loop->expects($this->once())->method('addTimer')->with(5.0, $this->anything())->willReturn($timer);
         $this->loop->expects($this->once())->method('cancelTimer')->with($timer);
 
@@ -89,7 +92,7 @@ class TimeoutExecutorTest extends TestCase
 
     public function testResolvesPromiseAfterCancellingTimerWhenWrappedReturnsPendingPromiseThatResolves()
     {
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
         $this->loop->expects($this->once())->method('addTimer')->with(5.0, $this->anything())->willReturn($timer);
         $this->loop->expects($this->once())->method('cancelTimer')->with($timer);
 
@@ -125,7 +128,7 @@ class TimeoutExecutorTest extends TestCase
 
     public function testRejectsPromiseAfterCancellingTimerWhenWrappedReturnsPendingPromiseThatRejects()
     {
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
         $this->loop->expects($this->once())->method('addTimer')->with(5.0, $this->anything())->willReturn($timer);
         $this->loop->expects($this->once())->method('cancelTimer')->with($timer);
 
@@ -146,7 +149,7 @@ class TimeoutExecutorTest extends TestCase
     public function testRejectsPromiseAndCancelsPendingQueryWhenTimeoutTriggers()
     {
         $timerCallback = null;
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
         $this->loop->expects($this->once())->method('addTimer')->with(5.0, $this->callback(function ($callback) use (&$timerCallback) {
             $timerCallback = $callback;
             return true;
@@ -183,7 +186,7 @@ class TimeoutExecutorTest extends TestCase
         });
 
         assert($exception instanceof TimeoutException);
-        $this->assertInstanceOf('React\Dns\Query\TimeoutException', $exception);
+        $this->assertInstanceOf(TimeoutException::class, $exception);
         $this->assertEquals('DNS query for igor.io (A) timed out' , $exception->getMessage());
     }
 }

--- a/tests/Query/UdpTransportExecutorTest.php
+++ b/tests/Query/UdpTransportExecutorTest.php
@@ -32,32 +32,32 @@ class UdpTransportExecutorTest extends TestCase
 
     public static function provideDefaultPortProvider()
     {
-        return array(
-            array(
+        return [
+            [
                 '8.8.8.8',
                 'udp://8.8.8.8:53'
-            ),
-            array(
+            ],
+            [
                 '1.2.3.4:5',
                 'udp://1.2.3.4:5'
-            ),
-            array(
+            ],
+            [
                 'udp://1.2.3.4',
                 'udp://1.2.3.4:53'
-            ),
-            array(
+            ],
+            [
                 'udp://1.2.3.4:53',
                 'udp://1.2.3.4:53'
-            ),
-            array(
+            ],
+            [
                 '::1',
                 'udp://[::1]:53'
-            ),
-            array(
+            ],
+            [
                 '[::1]:53',
                 'udp://[::1]:53'
-            )
-        );
+            ]
+        ];
     }
 
     public function testCtorWithoutLoopShouldAssignDefaultLoop()
@@ -122,10 +122,6 @@ class UdpTransportExecutorTest extends TestCase
 
     public function testQueryRejectsIfServerConnectionFails()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('HHVM reports different error message for invalid addresses');
-        }
-
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->never())->method('addReadStream');
 

--- a/tests/Resolver/ResolveAliasesTest.php
+++ b/tests/Resolver/ResolveAliasesTest.php
@@ -31,52 +31,52 @@ class ResolveAliasesTest extends TestCase
 
     public function provideAliasedAnswers()
     {
-        return array(
-            array(
-                array('178.79.169.131'),
-                array(
+        return [
+            [
+                ['178.79.169.131'],
+                [
                     new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                ),
+                ],
                 'igor.io',
-            ),
-            array(
-                array('178.79.169.131', '178.79.169.132', '178.79.169.133'),
-                array(
+            ],
+            [
+                ['178.79.169.131', '178.79.169.132', '178.79.169.133'],
+                [
                     new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
                     new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.132'),
                     new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.133'),
-                ),
+                ],
                 'igor.io',
-            ),
-            array(
-                array('178.79.169.131'),
-                array(
+            ],
+            [
+                ['178.79.169.131'],
+                [
                     new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
                     new Record('foo.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
                     new Record('bar.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                ),
+                ],
                 'igor.io',
-            ),
-            array(
-                array('178.79.169.131'),
-                array(
+            ],
+            [
+                ['178.79.169.131'],
+                [
                     new Record('igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'foo.igor.io'),
                     new Record('foo.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                ),
+                ],
                 'igor.io',
-            ),
-            array(
-                array('178.79.169.131'),
-                array(
+            ],
+            [
+                ['178.79.169.131'],
+                [
                     new Record('igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'foo.igor.io'),
                     new Record('foo.igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'bar.igor.io'),
                     new Record('bar.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                ),
+                ],
                 'igor.io',
-            ),
-            array(
-                array('178.79.169.131', '178.79.169.132', '178.79.169.133'),
-                array(
+            ],
+            [
+                ['178.79.169.131', '178.79.169.132', '178.79.169.133'],
+                [
                     new Record('igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'foo.igor.io'),
                     new Record('foo.igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'bar.igor.io'),
                     new Record('bar.igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'baz.igor.io'),
@@ -84,10 +84,10 @@ class ResolveAliasesTest extends TestCase
                     new Record('baz.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
                     new Record('baz.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.132'),
                     new Record('qux.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.133'),
-                ),
+                ],
                 'igor.io',
-            ),
-        );
+            ],
+        ];
     }
 
     private function createExecutorMock()

--- a/tests/Resolver/ResolveAliasesTest.php
+++ b/tests/Resolver/ResolveAliasesTest.php
@@ -2,10 +2,12 @@
 
 namespace React\Tests\Dns\Resolver;
 
-use React\Tests\Dns\TestCase;
-use React\Dns\Resolver\Resolver;
 use React\Dns\Model\Message;
 use React\Dns\Model\Record;
+use React\Dns\Query\ExecutorInterface;
+use React\Dns\Resolver\Resolver;
+use React\Tests\Dns\TestCase;
+use function React\Promise\resolve;
 
 class ResolveAliasesTest extends TestCase
 {
@@ -20,7 +22,7 @@ class ResolveAliasesTest extends TestCase
         }
 
         $executor = $this->createExecutorMock();
-        $executor->expects($this->once())->method('query')->willReturn(\React\Promise\resolve($message));
+        $executor->expects($this->once())->method('query')->willReturn(resolve($message));
 
         $resolver = new Resolver($executor);
 
@@ -31,67 +33,65 @@ class ResolveAliasesTest extends TestCase
 
     public function provideAliasedAnswers()
     {
-        return [
+        yield [
+            ['178.79.169.131'],
             [
-                ['178.79.169.131'],
-                [
-                    new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                ],
-                'igor.io',
+                new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
             ],
+            'igor.io',
+        ];
+        yield [
+            ['178.79.169.131', '178.79.169.132', '178.79.169.133'],
             [
-                ['178.79.169.131', '178.79.169.132', '178.79.169.133'],
-                [
-                    new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                    new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.132'),
-                    new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.133'),
-                ],
-                'igor.io',
+                new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
+                new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.132'),
+                new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.133'),
             ],
+            'igor.io',
+        ];
+        yield [
+            ['178.79.169.131'],
             [
-                ['178.79.169.131'],
-                [
-                    new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                    new Record('foo.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                    new Record('bar.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                ],
-                'igor.io',
+                new Record('igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
+                new Record('foo.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
+                new Record('bar.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
             ],
+            'igor.io',
+        ];
+        yield [
+            ['178.79.169.131'],
             [
-                ['178.79.169.131'],
-                [
-                    new Record('igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'foo.igor.io'),
-                    new Record('foo.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                ],
-                'igor.io',
+                new Record('igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'foo.igor.io'),
+                new Record('foo.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
             ],
+            'igor.io',
+        ];
+        yield [
+            ['178.79.169.131'],
             [
-                ['178.79.169.131'],
-                [
-                    new Record('igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'foo.igor.io'),
-                    new Record('foo.igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'bar.igor.io'),
-                    new Record('bar.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                ],
-                'igor.io',
+                new Record('igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'foo.igor.io'),
+                new Record('foo.igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'bar.igor.io'),
+                new Record('bar.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
             ],
+            'igor.io',
+        ];
+        yield [
+            ['178.79.169.131', '178.79.169.132', '178.79.169.133'],
             [
-                ['178.79.169.131', '178.79.169.132', '178.79.169.133'],
-                [
-                    new Record('igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'foo.igor.io'),
-                    new Record('foo.igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'bar.igor.io'),
-                    new Record('bar.igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'baz.igor.io'),
-                    new Record('bar.igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'qux.igor.io'),
-                    new Record('baz.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
-                    new Record('baz.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.132'),
-                    new Record('qux.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.133'),
-                ],
-                'igor.io',
+                new Record('igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'foo.igor.io'),
+                new Record('foo.igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'bar.igor.io'),
+                new Record('bar.igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'baz.igor.io'),
+                new Record('bar.igor.io', Message::TYPE_CNAME, Message::CLASS_IN, 3600, 'qux.igor.io'),
+                new Record('baz.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.131'),
+                new Record('baz.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.132'),
+                new Record('qux.igor.io', Message::TYPE_A, Message::CLASS_IN, 3600, '178.79.169.133'),
             ],
+            'igor.io',
         ];
     }
 
     private function createExecutorMock()
     {
-        return $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        return $this->createMock(ExecutorInterface::class);
     }
 }

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -2,12 +2,13 @@
 
 namespace React\Tests\Dns\Resolver;
 
-use React\Dns\Resolver\Resolver;
-use React\Dns\Query\Query;
 use React\Dns\Model\Message;
 use React\Dns\Model\Record;
-use React\Tests\Dns\TestCase;
+use React\Dns\Query\ExecutorInterface;
+use React\Dns\Query\Query;
 use React\Dns\RecordNotFoundException;
+use React\Dns\Resolver\Resolver;
+use React\Tests\Dns\TestCase;
 use function React\Promise\resolve;
 
 class ResolverTest extends TestCase
@@ -19,7 +20,7 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf(Query::class))
             ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
@@ -40,7 +41,7 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf(Query::class))
             ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
@@ -61,7 +62,7 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf(Query::class))
             ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
@@ -83,7 +84,7 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf(Query::class))
             ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
@@ -108,7 +109,7 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf(Query::class))
             ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
@@ -129,7 +130,7 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf(Query::class))
             ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
@@ -139,7 +140,7 @@ class ResolverTest extends TestCase
                 return resolve($response);
             }));
 
-        $errback = $this->expectCallableOnceWith($this->isInstanceOf('React\Dns\RecordNotFoundException'));
+        $errback = $this->expectCallableOnceWith($this->isInstanceOf(RecordNotFoundException::class));
 
         $resolver = new Resolver($executor);
         $resolver->resolve('igor.io')->then($this->expectCallableNever(), $errback);
@@ -154,7 +155,7 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf(Query::class))
             ->will($this->returnCallback(function ($query) {
                 $response = new Message();
                 $response->qr = true;
@@ -173,31 +174,29 @@ class ResolverTest extends TestCase
 
     public function provideRcodeErrors()
     {
-        return [
-            [
-                Message::RCODE_FORMAT_ERROR,
-                'DNS query for example.com (A) returned an error response (Format Error)',
-            ],
-            [
-                Message::RCODE_SERVER_FAILURE,
-                'DNS query for example.com (A) returned an error response (Server Failure)',
-            ],
-            [
-                Message::RCODE_NAME_ERROR,
-                'DNS query for example.com (A) returned an error response (Non-Existent Domain / NXDOMAIN)'
-            ],
-            [
-                Message::RCODE_NOT_IMPLEMENTED,
-                'DNS query for example.com (A) returned an error response (Not Implemented)'
-            ],
-            [
-                Message::RCODE_REFUSED,
-                'DNS query for example.com (A) returned an error response (Refused)'
-            ],
-            [
-                99,
-                'DNS query for example.com (A) returned an error response (Unknown error response code 99)'
-            ]
+        yield  [
+            Message::RCODE_FORMAT_ERROR,
+            'DNS query for example.com (A) returned an error response (Format Error)',
+        ];
+        yield [
+            Message::RCODE_SERVER_FAILURE,
+            'DNS query for example.com (A) returned an error response (Server Failure)',
+        ];
+        yield [
+            Message::RCODE_NAME_ERROR,
+            'DNS query for example.com (A) returned an error response (Non-Existent Domain / NXDOMAIN)'
+        ];
+        yield [
+            Message::RCODE_NOT_IMPLEMENTED,
+            'DNS query for example.com (A) returned an error response (Not Implemented)'
+        ];
+        yield [
+            Message::RCODE_REFUSED,
+            'DNS query for example.com (A) returned an error response (Refused)'
+        ];
+        yield [
+            99,
+            'DNS query for example.com (A) returned an error response (Unknown error response code 99)'
         ];
     }
 
@@ -211,7 +210,7 @@ class ResolverTest extends TestCase
         $executor
             ->expects($this->once())
             ->method('query')
-            ->with($this->isInstanceOf('React\Dns\Query\Query'))
+            ->with($this->isInstanceOf(Query::class))
             ->will($this->returnCallback(function ($query) use ($code) {
                 $response = new Message();
                 $response->qr = true;
@@ -231,6 +230,6 @@ class ResolverTest extends TestCase
 
     private function createExecutorMock()
     {
-        return $this->getMockBuilder('React\Dns\Query\ExecutorInterface')->getMock();
+        return $this->createMock(ExecutorInterface::class);
     }
 }

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -6,9 +6,9 @@ use React\Dns\Resolver\Resolver;
 use React\Dns\Query\Query;
 use React\Dns\Model\Message;
 use React\Dns\Model\Record;
-use React\Promise;
 use React\Tests\Dns\TestCase;
 use React\Dns\RecordNotFoundException;
+use function React\Promise\resolve;
 
 class ResolverTest extends TestCase
 {
@@ -26,7 +26,7 @@ class ResolverTest extends TestCase
                 $response->questions[] = new Query($query->name, $query->type, $query->class);
                 $response->answers[] = new Record($query->name, $query->type, $query->class, 3600, '178.79.169.131');
 
-                return Promise\resolve($response);
+                return resolve($response);
             }));
 
         $resolver = new Resolver($executor);
@@ -47,11 +47,11 @@ class ResolverTest extends TestCase
                 $response->questions[] = new Query($query->name, $query->type, $query->class);
                 $response->answers[] = new Record($query->name, $query->type, $query->class, 3600, '::1');
 
-                return Promise\resolve($response);
+                return resolve($response);
             }));
 
         $resolver = new Resolver($executor);
-        $resolver->resolveAll('reactphp.org', Message::TYPE_AAAA)->then($this->expectCallableOnceWith(array('::1')));
+        $resolver->resolveAll('reactphp.org', Message::TYPE_AAAA)->then($this->expectCallableOnceWith(['::1']));
     }
 
     /** @test */
@@ -66,14 +66,14 @@ class ResolverTest extends TestCase
                 $response = new Message();
                 $response->qr = true;
                 $response->questions[] = new Query($query->name, $query->type, $query->class);
-                $response->answers[] = new Record($query->name, Message::TYPE_TXT, $query->class, 3600, array('ignored'));
+                $response->answers[] = new Record($query->name, Message::TYPE_TXT, $query->class, 3600, ['ignored']);
                 $response->answers[] = new Record($query->name, $query->type, $query->class, 3600, '::1');
 
-                return Promise\resolve($response);
+                return resolve($response);
             }));
 
         $resolver = new Resolver($executor);
-        $resolver->resolveAll('reactphp.org', Message::TYPE_AAAA)->then($this->expectCallableOnceWith(array('::1')));
+        $resolver->resolveAll('reactphp.org', Message::TYPE_AAAA)->then($this->expectCallableOnceWith(['::1']));
     }
 
     /** @test */
@@ -92,12 +92,12 @@ class ResolverTest extends TestCase
                 $response->answers[] = new Record('example.com', $query->type, $query->class, 3600, '::1');
                 $response->answers[] = new Record('example.com', $query->type, $query->class, 3600, '::2');
 
-                return Promise\resolve($response);
+                return resolve($response);
             }));
 
         $resolver = new Resolver($executor);
         $resolver->resolveAll('reactphp.org', Message::TYPE_AAAA)->then(
-            $this->expectCallableOnceWith($this->equalTo(array('::1', '::2')))
+            $this->expectCallableOnceWith($this->equalTo(['::1', '::2']))
         );
     }
 
@@ -115,7 +115,7 @@ class ResolverTest extends TestCase
                 $response->questions[] = new Query('Blog.wyrihaximus.net', $query->type, $query->class);
                 $response->answers[] = new Record('Blog.wyrihaximus.net', $query->type, $query->class, 3600, '178.79.169.131');
 
-                return Promise\resolve($response);
+                return resolve($response);
             }));
 
         $resolver = new Resolver($executor);
@@ -136,7 +136,7 @@ class ResolverTest extends TestCase
                 $response->questions[] = new Query($query->name, $query->type, $query->class);
                 $response->answers[] = new Record('foo.bar', $query->type, $query->class, 3600, '178.79.169.131');
 
-                return Promise\resolve($response);
+                return resolve($response);
             }));
 
         $errback = $this->expectCallableOnceWith($this->isInstanceOf('React\Dns\RecordNotFoundException'));
@@ -160,7 +160,7 @@ class ResolverTest extends TestCase
                 $response->qr = true;
                 $response->questions[] = new Query($query->name, $query->type, $query->class);
 
-                return Promise\resolve($response);
+                return resolve($response);
             }));
 
         $errback = $this->expectCallableOnceWith($this->callback(function ($param) {
@@ -173,32 +173,32 @@ class ResolverTest extends TestCase
 
     public function provideRcodeErrors()
     {
-        return array(
-            array(
+        return [
+            [
                 Message::RCODE_FORMAT_ERROR,
                 'DNS query for example.com (A) returned an error response (Format Error)',
-            ),
-            array(
+            ],
+            [
                 Message::RCODE_SERVER_FAILURE,
                 'DNS query for example.com (A) returned an error response (Server Failure)',
-            ),
-            array(
+            ],
+            [
                 Message::RCODE_NAME_ERROR,
                 'DNS query for example.com (A) returned an error response (Non-Existent Domain / NXDOMAIN)'
-            ),
-            array(
+            ],
+            [
                 Message::RCODE_NOT_IMPLEMENTED,
                 'DNS query for example.com (A) returned an error response (Not Implemented)'
-            ),
-            array(
+            ],
+            [
                 Message::RCODE_REFUSED,
                 'DNS query for example.com (A) returned an error response (Refused)'
-            ),
-            array(
+            ],
+            [
                 99,
                 'DNS query for example.com (A) returned an error response (Unknown error response code 99)'
-            )
-        );
+            ]
+        ];
     }
 
     /**
@@ -218,7 +218,7 @@ class ResolverTest extends TestCase
                 $response->rcode = $code;
                 $response->questions[] = new Query($query->name, $query->type, $query->class);
 
-                return Promise\resolve($response);
+                return resolve($response);
             }));
 
         $errback = $this->expectCallableOnceWith($this->callback(function ($param) use ($code, $expectedMessage) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,10 +41,10 @@ abstract class TestCase extends BaseTestCase
     {
         if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
             // PHPUnit 9+
-            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+            return $this->getMockBuilder('stdClass')->addMethods(['__invoke'])->getMock();
         } else {
-            // legacy PHPUnit 4 - PHPUnit 9
-            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+            // legacy PHPUnit
+            return $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
         }
     }
 
@@ -60,7 +60,7 @@ abstract class TestCase extends BaseTestCase
                  $this->expectExceptionCode($exceptionCode);
              }
          } else {
-             // legacy PHPUnit 4
+             // legacy PHPUnit
              parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
          }
      }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,29 +39,13 @@ abstract class TestCase extends BaseTestCase
 
     protected function createCallableMock()
     {
-        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+        $builder = $this->getMockBuilder(\stdClass::class);
+        if (method_exists($builder, 'addMethods')) {
             // PHPUnit 9+
-            return $this->getMockBuilder('stdClass')->addMethods(['__invoke'])->getMock();
+            return $builder->addMethods(['__invoke'])->getMock();
         } else {
             // legacy PHPUnit
-            return $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
+            return $builder->setMethods(['__invoke'])->getMock();
         }
     }
-
-    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
-    {
-         if (method_exists($this, 'expectException')) {
-             // PHPUnit 5
-             $this->expectException($exception);
-             if ($exceptionMessage !== '') {
-                 $this->expectExceptionMessage($exceptionMessage);
-             }
-             if ($exceptionCode !== null) {
-                 $this->expectExceptionCode($exceptionCode);
-             }
-         } else {
-             // legacy PHPUnit
-             parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
-         }
-     }
 }


### PR DESCRIPTION
This changeset updates the project to require PHP 7.1+ and drop legacy PHP < 7.1 and HHVM as discussed in #219. I'm marking this as a BC break for anybody still stuck on very old PHP versions, but there's little chance this will affect any current projects otherwise.

This PR aims to contain the minimal changeset to update the PHP version requirement only. Follow-up PRs will update our APIs to leverage newer language features.

FYI: I used https://github.com/reactphp/cache/pull/58, https://github.com/reactphp/stream/pull/175 and https://github.com/reactphp/event-loop/pull/276 as inspiration.

Builds on top of #101, #170, #217, #220 and others