### PR TITLE
[3.x] Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
         "php": ">=7.1",
         "react/cache": "^1.0 || ^0.6 || ^0.5",
         "react/event-loop": "^1.2",
-        "react/promise": "^3.0 || ^2.7 || ^1.2.1"
+        "react/promise": "^3.2 || ^2.7 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^7.5",
-        "react/async": "^4 || ^3 || ^2",
-        "react/promise-timer": "^1.9"
+        "react/async": "^4.3 || ^3 || ^2",
+        "react/promise-timer": "^1.11"
     },
     "autoload": {
         "psr-4": {

--- a/src/Query/TcpTransportExecutor.php
+++ b/src/Query/TcpTransportExecutor.php
@@ -135,7 +135,7 @@ class TcpTransportExecutor implements ExecutorInterface
      * @param string         $nameserver
      * @param ?LoopInterface $loop
      */
-    public function __construct($nameserver, LoopInterface $loop = null)
+    public function __construct($nameserver, ?LoopInterface $loop = null)
     {
         if (\strpos($nameserver, '[') === false && \substr_count($nameserver, ':') >= 2 && \strpos($nameserver, '://') === false) {
             // several colons, but not enclosed in square brackets => enclose IPv6 address in square brackets

--- a/src/Query/TimeoutExecutor.php
+++ b/src/Query/TimeoutExecutor.php
@@ -12,7 +12,7 @@ final class TimeoutExecutor implements ExecutorInterface
     private $loop;
     private $timeout;
 
-    public function __construct(ExecutorInterface $executor, $timeout, LoopInterface $loop = null)
+    public function __construct(ExecutorInterface $executor, $timeout, ?LoopInterface $loop = null)
     {
         $this->executor = $executor;
         $this->loop = $loop ?: Loop::get();

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -99,7 +99,7 @@ final class UdpTransportExecutor implements ExecutorInterface
      * @param string         $nameserver
      * @param ?LoopInterface $loop
      */
-    public function __construct($nameserver, LoopInterface $loop = null)
+    public function __construct($nameserver, ?LoopInterface $loop = null)
     {
         if (\strpos($nameserver, '[') === false && \substr_count($nameserver, ':') >= 2 && \strpos($nameserver, '://') === false) {
             // several colons, but not enclosed in square brackets => enclose IPv6 address in square brackets

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -36,7 +36,7 @@ final class Factory
      * @throws \InvalidArgumentException for invalid DNS server address
      * @throws \UnderflowException when given DNS Config object has an empty list of nameservers
      */
-    public function create($config, LoopInterface $loop = null)
+    public function create($config, ?LoopInterface $loop = null)
     {
         $executor = $this->decorateHostsFileExecutor($this->createExecutor($config, $loop ?: Loop::get()));
 
@@ -59,7 +59,7 @@ final class Factory
      * @throws \InvalidArgumentException for invalid DNS server address
      * @throws \UnderflowException when given DNS Config object has an empty list of nameservers
      */
-    public function createCached($config, LoopInterface $loop = null, CacheInterface $cache = null)
+    public function createCached($config, ?LoopInterface $loop = null, ?CacheInterface $cache = null)
     {
         // default to keeping maximum of 256 responses in cache unless explicitly given
         if (!($cache instanceof CacheInterface)) {


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260.

I'm planning to add native types to the public API and introduce PHPStan in follow-up PRs.

Once merged, we should apply similar changes to all our upcoming v3 components. On top of this, we should backport similar changes to the v1 branch.

Builds on top of #182, #222, https://github.com/reactphp/promise/pull/260, https://github.com/reactphp/async/pull/87 and https://github.com/reactphp/promise-timer/pull/70