### PR TITLE
Add native types to public API

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -26,7 +26,7 @@ final class Config
      * @return self
      * @codeCoverageIgnore
      */
-    public static function loadSystemConfigBlocking()
+    public static function loadSystemConfigBlocking(): self
     {
         // Use WMIC output on Windows
         if (DIRECTORY_SEPARATOR === '\\') {
@@ -71,7 +71,7 @@ final class Config
      * @return self
      * @throws RuntimeException if the path can not be loaded (does not exist)
      */
-    public static function loadResolvConfBlocking($path = null)
+    public static function loadResolvConfBlocking(?string $path = null): self
     {
         if ($path === null) {
             $path = '/etc/resolv.conf';
@@ -122,7 +122,7 @@ final class Config
      * @return self
      * @link https://ss64.com/nt/wmic.html
      */
-    public static function loadWmicBlocking($command = null)
+    public static function loadWmicBlocking(?string $command = null): self
     {
         $contents = shell_exec($command === null ? 'wmic NICCONFIG get "DNSServerSearchOrder" /format:CSV' : $command);
         preg_match_all('/(?<=[{;,"])([\da-f.:]{4,})(?=[};,"])/i', $contents, $matches);
@@ -133,5 +133,8 @@ final class Config
         return $config;
     }
 
+    /**
+     * @var array<string>
+     */
     public $nameservers = [];
 }

--- a/src/Config/HostsFile.php
+++ b/src/Config/HostsFile.php
@@ -27,7 +27,7 @@ class HostsFile
      * @return string
      * @codeCoverageIgnore
      */
-    public static function getDefaultPath()
+    public static function getDefaultPath(): string
     {
         // use static path for all Unix-based systems
         if (DIRECTORY_SEPARATOR !== '\\') {
@@ -59,7 +59,7 @@ class HostsFile
      * @return self
      * @throws RuntimeException if the path can not be loaded (does not exist)
      */
-    public static function loadFromPathBlocking($path = null)
+    public static function loadFromPathBlocking(?string $path = null): self
     {
         if ($path === null) {
             $path = self::getDefaultPath();
@@ -80,7 +80,7 @@ class HostsFile
      *
      * @param string $contents
      */
-    public function __construct($contents)
+    public function __construct(string $contents)
     {
         // remove all comments from the contents
         $contents = preg_replace('/[ \t]*#.*/', '', strtolower($contents));
@@ -92,9 +92,9 @@ class HostsFile
      * Returns all IPs for the given hostname
      *
      * @param string $name
-     * @return string[]
+     * @return array<string>
      */
-    public function getIpsForHost($name)
+    public function getIpsForHost(string $name): array
     {
         $name = strtolower($name);
 
@@ -121,9 +121,9 @@ class HostsFile
      * Returns all hostnames for the given IPv4 or IPv6 address
      *
      * @param string $ip
-     * @return string[]
+     * @return array<string>
      */
-    public function getHostsForIp($ip)
+    public function getHostsForIp(string $ip): array
     {
         // check binary representation of IP to avoid string case and short notation
         $ip = @inet_pton($ip);

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -86,7 +86,7 @@ final class Message
      * @param Query $query
      * @return self
      */
-    public static function createRequestForQuery(Query $query)
+    public static function createRequestForQuery(Query $query): self
     {
         $request = new Message();
         $request->id = self::generateId();
@@ -99,11 +99,11 @@ final class Message
     /**
      * Creates a new response message for the given query with the given answer records
      *
-     * @param Query    $query
-     * @param Record[] $answers
+     * @param Query         $query
+     * @param array<Record> $answers
      * @return self
      */
-    public static function createResponseWithAnswersForQuery(Query $query, array $answers)
+    public static function createResponseWithAnswersForQuery(Query $query, array $answers): self
     {
         $response = new Message();
         $response->id = self::generateId();
@@ -199,22 +199,22 @@ final class Message
      * ];
      * ```
      *
-     * @var Query[]
+     * @var array<Query>
      */
     public $questions = [];
 
     /**
-     * @var Record[]
+     * @var array<Record>
      */
     public $answers = [];
 
     /**
-     * @var Record[]
+     * @var array<Record>
      */
     public $authority = [];
 
     /**
-     * @var Record[]
+     * @var array<Record>
      */
     public $additional = [];
 }

--- a/src/Model/Record.php
+++ b/src/Model/Record.php
@@ -131,18 +131,18 @@ final class Record
      *   considered a BC break. See the format definition of known types above
      *   for more details.
      *
-     * @var string|string[]|array
+     * @var string|array<string>
      */
     public $data;
 
     /**
-     * @param string                $name
-     * @param int                   $type
-     * @param int                   $class
-     * @param int                   $ttl
-     * @param string|string[]|array $data
+     * @param string               $name
+     * @param int                  $type
+     * @param int                  $class
+     * @param int                  $ttl
+     * @param string|array<string> $data
      */
-    public function __construct($name, $type, $class, $ttl, $data)
+    public function __construct(string $name, int $type, int $class, int $ttl, $data)
     {
         $this->name     = $name;
         $this->type     = $type;

--- a/src/Protocol/BinaryDumper.php
+++ b/src/Protocol/BinaryDumper.php
@@ -8,11 +8,7 @@ use React\Dns\Query\Query;
 
 final class BinaryDumper
 {
-    /**
-     * @param Message $message
-     * @return string
-     */
-    public function toBinary(Message $message)
+    public function toBinary(Message $message): string
     {
         $data = '';
 

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -21,7 +21,7 @@ final class Parser
      * @throws InvalidArgumentException
      * @return Message
      */
-    public function parseMessage($data)
+    public function parseMessage(string $data): Message
     {
         $message = $this->parse($data, 0);
         if ($message === null) {

--- a/src/Query/CachingExecutor.php
+++ b/src/Query/CachingExecutor.php
@@ -5,6 +5,7 @@ namespace React\Dns\Query;
 use React\Cache\CacheInterface;
 use React\Dns\Model\Message;
 use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 
 final class CachingExecutor implements ExecutorInterface
 {
@@ -24,7 +25,7 @@ final class CachingExecutor implements ExecutorInterface
         $this->cache = $cache;
     }
 
-    public function query(Query $query)
+    public function query(Query $query): PromiseInterface
     {
         $id = $query->name . ':' . $query->type . ':' . $query->class;
 

--- a/src/Query/CoopExecutor.php
+++ b/src/Query/CoopExecutor.php
@@ -3,6 +3,7 @@
 namespace React\Dns\Query;
 
 use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 
 /**
  * Cooperatively resolves hosts via the given base executor to ensure same query is not run concurrently
@@ -45,7 +46,7 @@ final class CoopExecutor implements ExecutorInterface
         $this->executor = $base;
     }
 
-    public function query(Query $query)
+    public function query(Query $query): PromiseInterface
     {
         $key = $this->serializeQueryToIdentity($query);
         if (isset($this->pending[$key])) {

--- a/src/Query/ExecutorInterface.php
+++ b/src/Query/ExecutorInterface.php
@@ -2,6 +2,8 @@
 
 namespace React\Dns\Query;
 
+use React\Promise\PromiseInterface;
+
 interface ExecutorInterface
 {
     /**
@@ -39,5 +41,5 @@ interface ExecutorInterface
      * @return \React\Promise\PromiseInterface<\React\Dns\Model\Message>
      *     resolves with response message on success or rejects with an Exception on error
      */
-    public function query(Query $query);
+    public function query(Query $query): PromiseInterface;
 }

--- a/src/Query/FallbackExecutor.php
+++ b/src/Query/FallbackExecutor.php
@@ -3,6 +3,7 @@
 namespace React\Dns\Query;
 
 use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 
 final class FallbackExecutor implements ExecutorInterface
 {
@@ -15,7 +16,7 @@ final class FallbackExecutor implements ExecutorInterface
         $this->fallback = $fallback;
     }
 
-    public function query(Query $query)
+    public function query(Query $query): PromiseInterface
     {
         $cancelled = false;
         $promise = $this->executor->query($query);

--- a/src/Query/HostsFileExecutor.php
+++ b/src/Query/HostsFileExecutor.php
@@ -5,6 +5,7 @@ namespace React\Dns\Query;
 use React\Dns\Config\HostsFile;
 use React\Dns\Model\Message;
 use React\Dns\Model\Record;
+use React\Promise\PromiseInterface;
 use function React\Promise\resolve;
 
 /**
@@ -25,7 +26,7 @@ final class HostsFileExecutor implements ExecutorInterface
         $this->fallback = $fallback;
     }
 
-    public function query(Query $query)
+    public function query(Query $query): PromiseInterface
     {
         if ($query->class === Message::CLASS_IN && ($query->type === Message::TYPE_A || $query->type === Message::TYPE_AAAA)) {
             // forward lookup for type A or AAAA

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -35,7 +35,7 @@ final class Query
      * @param int    $type  query type, see Message::TYPE_* constants
      * @param int    $class query class, see Message::CLASS_IN constant
      */
-    public function __construct($name, $type, $class)
+    public function __construct(string $name, int $type, int $class)
     {
         $this->name = $name;
         $this->type = $type;
@@ -51,7 +51,7 @@ final class Query
      * @return string "example.com (A)" or "example.com (CLASS0 TYPE1234)"
      * @link https://tools.ietf.org/html/rfc3597
      */
-    public function describe()
+    public function describe(): string
     {
         $class = $this->class !== Message::CLASS_IN ? 'CLASS' . $this->class . ' ' : '';
 

--- a/src/Query/RetryExecutor.php
+++ b/src/Query/RetryExecutor.php
@@ -10,18 +10,18 @@ final class RetryExecutor implements ExecutorInterface
     private $executor;
     private $retries;
 
-    public function __construct(ExecutorInterface $executor, $retries = 2)
+    public function __construct(ExecutorInterface $executor, int $retries = 2)
     {
         $this->executor = $executor;
         $this->retries = $retries;
     }
 
-    public function query(Query $query)
+    public function query(Query $query): PromiseInterface
     {
         return $this->tryQuery($query, $this->retries);
     }
 
-    public function tryQuery(Query $query, $retries)
+    public function tryQuery(Query $query, int $retries): PromiseInterface
     {
         $deferred = new Deferred(function () use (&$promise) {
             if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {

--- a/src/Query/SelectiveTransportExecutor.php
+++ b/src/Query/SelectiveTransportExecutor.php
@@ -3,6 +3,7 @@
 namespace React\Dns\Query;
 
 use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 
 /**
  * Send DNS queries over a UDP or TCP/IP stream transport.
@@ -61,7 +62,7 @@ class SelectiveTransportExecutor implements ExecutorInterface
         $this->streamExecutor = $streamExecutor;
     }
 
-    public function query(Query $query)
+    public function query(Query $query): PromiseInterface
     {
         $pending = $this->datagramExecutor->query($query);
 

--- a/src/Query/TcpTransportExecutor.php
+++ b/src/Query/TcpTransportExecutor.php
@@ -8,6 +8,7 @@ use React\Dns\Protocol\Parser;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
 use function React\Promise\reject;
 
 /**
@@ -135,7 +136,7 @@ class TcpTransportExecutor implements ExecutorInterface
      * @param string         $nameserver
      * @param ?LoopInterface $loop
      */
-    public function __construct($nameserver, ?LoopInterface $loop = null)
+    public function __construct(string $nameserver, ?LoopInterface $loop = null)
     {
         if (\strpos($nameserver, '[') === false && \substr_count($nameserver, ':') >= 2 && \strpos($nameserver, '://') === false) {
             // several colons, but not enclosed in square brackets => enclose IPv6 address in square brackets
@@ -153,7 +154,7 @@ class TcpTransportExecutor implements ExecutorInterface
         $this->dumper = new BinaryDumper();
     }
 
-    public function query(Query $query)
+    public function query(Query $query): PromiseInterface
     {
         $request = Message::createRequestForQuery($query);
 

--- a/src/Query/TimeoutExecutor.php
+++ b/src/Query/TimeoutExecutor.php
@@ -5,6 +5,7 @@ namespace React\Dns\Query;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 
 final class TimeoutExecutor implements ExecutorInterface
 {
@@ -12,14 +13,14 @@ final class TimeoutExecutor implements ExecutorInterface
     private $loop;
     private $timeout;
 
-    public function __construct(ExecutorInterface $executor, $timeout, ?LoopInterface $loop = null)
+    public function __construct(ExecutorInterface $executor, float $timeout, ?LoopInterface $loop = null)
     {
         $this->executor = $executor;
         $this->loop = $loop ?: Loop::get();
         $this->timeout = $timeout;
     }
 
-    public function query(Query $query)
+    public function query(Query $query): PromiseInterface
     {
         $promise = $this->executor->query($query);
 

--- a/src/Query/UdpTransportExecutor.php
+++ b/src/Query/UdpTransportExecutor.php
@@ -8,6 +8,7 @@ use React\Dns\Protocol\Parser;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
 use function React\Promise\reject;
 
 /**
@@ -99,7 +100,7 @@ final class UdpTransportExecutor implements ExecutorInterface
      * @param string         $nameserver
      * @param ?LoopInterface $loop
      */
-    public function __construct($nameserver, ?LoopInterface $loop = null)
+    public function __construct(string $nameserver, ?LoopInterface $loop = null)
     {
         if (\strpos($nameserver, '[') === false && \substr_count($nameserver, ':') >= 2 && \strpos($nameserver, '://') === false) {
             // several colons, but not enclosed in square brackets => enclose IPv6 address in square brackets
@@ -117,7 +118,7 @@ final class UdpTransportExecutor implements ExecutorInterface
         $this->dumper = new BinaryDumper();
     }
 
-    public function query(Query $query)
+    public function query(Query $query): PromiseInterface
     {
         $request = Message::createRequestForQuery($query);
 

--- a/src/Resolver/Factory.php
+++ b/src/Resolver/Factory.php
@@ -32,11 +32,11 @@ final class Factory
      *
      * @param Config|string  $config DNS Config object (recommended) or single nameserver address
      * @param ?LoopInterface $loop
-     * @return \React\Dns\Resolver\ResolverInterface
+     * @return ResolverInterface
      * @throws \InvalidArgumentException for invalid DNS server address
      * @throws \UnderflowException when given DNS Config object has an empty list of nameservers
      */
-    public function create($config, ?LoopInterface $loop = null)
+    public function create($config, ?LoopInterface $loop = null): ResolverInterface
     {
         $executor = $this->decorateHostsFileExecutor($this->createExecutor($config, $loop ?: Loop::get()));
 
@@ -55,11 +55,11 @@ final class Factory
      * @param Config|string   $config DNS Config object (recommended) or single nameserver address
      * @param ?LoopInterface  $loop
      * @param ?CacheInterface $cache
-     * @return \React\Dns\Resolver\ResolverInterface
+     * @return ResolverInterface
      * @throws \InvalidArgumentException for invalid DNS server address
      * @throws \UnderflowException when given DNS Config object has an empty list of nameservers
      */
-    public function createCached($config, ?LoopInterface $loop = null, ?CacheInterface $cache = null)
+    public function createCached($config, ?LoopInterface $loop = null, ?CacheInterface $cache = null): ResolverInterface
     {
         // default to keeping maximum of 256 responses in cache unless explicitly given
         if (!($cache instanceof CacheInterface)) {

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -6,6 +6,7 @@ use React\Dns\Model\Message;
 use React\Dns\Query\ExecutorInterface;
 use React\Dns\Query\Query;
 use React\Dns\RecordNotFoundException;
+use React\Promise\PromiseInterface;
 
 /**
  * @see ResolverInterface for the base interface
@@ -19,14 +20,14 @@ final class Resolver implements ResolverInterface
         $this->executor = $executor;
     }
 
-    public function resolve($domain)
+    public function resolve(string $domain): PromiseInterface
     {
         return $this->resolveAll($domain, Message::TYPE_A)->then(function (array $ips) {
             return $ips[array_rand($ips)];
         });
     }
 
-    public function resolveAll($domain, $type)
+    public function resolveAll(string $domain, int $type): PromiseInterface
     {
         $query = new Query($domain, $type, Message::CLASS_IN);
 

--- a/src/Resolver/ResolverInterface.php
+++ b/src/Resolver/ResolverInterface.php
@@ -2,6 +2,8 @@
 
 namespace React\Dns\Resolver;
 
+use React\Promise\PromiseInterface;
+
 interface ResolverInterface
 {
     /**
@@ -42,7 +44,7 @@ interface ResolverInterface
      * @return \React\Promise\PromiseInterface<string>
      *     resolves with a single IP address on success or rejects with an Exception on error.
      */
-    public function resolve($domain);
+    public function resolve(string $domain): PromiseInterface;
 
     /**
      * Resolves all record values for the given $domain name and query $type.
@@ -86,9 +88,10 @@ interface ResolverInterface
      * $promise->cancel();
      * ```
      *
-     * @param string $domain
-     * @return \React\Promise\PromiseInterface<array>
+     * @param string $domain domain to resolve
+     * @param int    $type   query type, see Message::TYPE_* constants
+     * @return \React\Promise\PromiseInterface<array<string>>
      *     Resolves with all record values on success or rejects with an Exception on error.
      */
-    public function resolveAll($domain, $type);
+    public function resolveAll(string $domain, int $type): PromiseInterface;
 }


### PR DESCRIPTION
This changeset adds native types to the public API as discussed in #219.

Once merged, I'm planning to add PHPStan in a follow-up PR which would take advantage of these types.

Builds on top of #222, #223 and reactphp/cache#60