### PR TITLE
[3.0] Strip FQDN period from the end of the domain

### DIFF
--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -28,6 +28,7 @@ final class Resolver implements ResolverInterface
 
     public function resolveAll($domain, $type)
     {
+        $domain = trim($domain, '.');
         $query = new Query($domain, $type, Message::CLASS_IN);
 
         return $this->executor->query(

--- a/tests/FunctionalResolverTest.php
+++ b/tests/FunctionalResolverTest.php
@@ -51,6 +51,17 @@ class FunctionalResolverTest extends TestCase
     /**
      * @group internet
      */
+    public function testResolveGoogleFQDNResolves()
+    {
+        $promise = $this->resolver->resolve('google.com.');
+        $promise->then($this->expectCallableOnce(), $this->expectCallableNever());
+
+        Loop::run();
+    }
+
+    /**
+     * @group internet
+     */
     public function testResolveGoogleOverUdpResolves()
     {
         $factory = new Factory();


### PR DESCRIPTION
As brought up in #229 we're already treating all domains as absolute, so adding direct support for it is a small bug fix. That said, fully support for search domains requires a different handling of this and will be done in a different PR.