### PR TITLE
[3.0] Downgrade Ubuntu runners to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php:


### PR DESCRIPTION
This PR superseeds: #235

Running the test suite on PHP 8+ results in the following two errors on Ubuntu 24.04. This PR doesn't aim to fix those errors, but to ensure we have a working CI test environment.

```
There were 2 failures:

1) React\Tests\Dns\Query\TcpTransportExecutorTest::testQueryStaysPendingWhenClientCanNotSendExcessiveMessageInOneChunkWhenServerClosesSocket
React\EventLoop\LoopInterface::removeWriteStream(resource(545) of type (stream)) was not expected to be called.

/home/runner/work/dns/dns/src/Query/TcpTransportExecutor.php:273
/home/runner/work/dns/dns/tests/Query/TcpTransportExecutorTest.php:347

2) React\Tests\Dns\Query\TcpTransportExecutorTest::testQueryRejectsWhenClientKeepsSendingWhenServerClosesSocketWithoutCallingCustomErrorHandler
Failed asserting that exception of type "Error" matches expected exception "RuntimeException". Message was: "Can only throw objects" at
/home/runner/work/dns/dns/tests/Query/TcpTransportExecutorTest.php:413
```