### PR TITLE
[1.x] Improve PHP 8.5+ support by avoiding deprecated `setAccessible()` calls

### DIFF
--- a/src/Query/RetryExecutor.php
+++ b/src/Query/RetryExecutor.php
@@ -50,7 +50,9 @@ final class RetryExecutor implements ExecutorInterface
                 // avoid garbage references by replacing all closures in call stack.
                 // what a lovely piece of code!
                 $r = new \ReflectionProperty('Exception', 'trace');
-                $r->setAccessible(true);
+                if (\PHP_VERSION_ID < 80100) {
+                    $r->setAccessible(true);
+                }
                 $trace = $r->getValue($e);
 
                 // Exception trace arguments are not available on some PHP 7.4 installs

--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -24,7 +24,9 @@ class TcpTransportExecutorTest extends TestCase
         $executor = new TcpTransportExecutor($input, $loop);
 
         $ref = new \ReflectionProperty($executor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $value = $ref->getValue($executor);
 
         $this->assertEquals($expected, $value);
@@ -65,7 +67,9 @@ class TcpTransportExecutorTest extends TestCase
         $executor = new TcpTransportExecutor('127.0.0.1');
 
         $ref = new \ReflectionProperty($executor, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($executor);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
@@ -127,7 +131,9 @@ class TcpTransportExecutorTest extends TestCase
         $executor = new TcpTransportExecutor('::1', $loop);
 
         $ref = new \ReflectionProperty($executor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($executor, '///');
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
@@ -306,7 +312,9 @@ class TcpTransportExecutorTest extends TestCase
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
 
         $ref = new \ReflectionProperty($executor, 'writePending');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $writePending = $ref->getValue($executor);
 
         $this->assertTrue($writePending);
@@ -348,7 +356,9 @@ class TcpTransportExecutorTest extends TestCase
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
 
         $ref = new \ReflectionProperty($executor, 'writePending');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $writePending = $ref->getValue($executor);
 
         $this->assertTrue($writePending);
@@ -389,7 +399,9 @@ class TcpTransportExecutorTest extends TestCase
         $executor->handleWritable();
 
         $ref = new \ReflectionProperty($executor, 'writePending');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $writePending = $ref->getValue($executor);
 
         // We expect an EPIPE (Broken pipe) on second write.
@@ -744,7 +756,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);
@@ -779,7 +793,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);
@@ -812,7 +828,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);
@@ -853,7 +871,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);
@@ -891,7 +911,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);
@@ -929,7 +951,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);

--- a/tests/Query/TimeoutExecutorTest.php
+++ b/tests/Query/TimeoutExecutorTest.php
@@ -34,7 +34,9 @@ class TimeoutExecutorTest extends TestCase
         $executor = new TimeoutExecutor($this->executor, 5.0);
 
         $ref = new \ReflectionProperty($executor, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($executor);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/Query/UdpTransportExecutorTest.php
+++ b/tests/Query/UdpTransportExecutorTest.php
@@ -24,7 +24,9 @@ class UdpTransportExecutorTest extends TestCase
         $executor = new UdpTransportExecutor($input, $loop);
 
         $ref = new \ReflectionProperty($executor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $value = $ref->getValue($executor);
 
         $this->assertEquals($expected, $value);
@@ -65,7 +67,9 @@ class UdpTransportExecutorTest extends TestCase
         $executor = new UdpTransportExecutor('127.0.0.1');
 
         $ref = new \ReflectionProperty($executor, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($executor);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
@@ -132,7 +136,9 @@ class UdpTransportExecutorTest extends TestCase
         $executor = new UdpTransportExecutor('::1', $loop);
 
         $ref = new \ReflectionProperty($executor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($executor, '///');
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
@@ -161,7 +167,9 @@ class UdpTransportExecutorTest extends TestCase
 
         // increase hard-coded maximum packet size to allow sending excessive data
         $ref = new \ReflectionProperty($executor, 'maxPacketSize');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($executor, PHP_INT_MAX);
 
         $error = null;

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -33,13 +33,17 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('React\Dns\Query\CoopExecutor', $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $selectiveExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\SelectiveTransportExecutor', $selectiveExecutor);
@@ -47,13 +51,17 @@ class FactoryTest extends TestCase
         // udp below:
 
         $ref = new \ReflectionProperty($selectiveExecutor, 'datagramExecutor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($selectiveExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $udpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\UdpTransportExecutor', $udpExecutor);
@@ -61,13 +69,17 @@ class FactoryTest extends TestCase
         // tcp below:
 
         $ref = new \ReflectionProperty($selectiveExecutor, 'streamExecutor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($selectiveExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
@@ -88,19 +100,25 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('React\Dns\Query\CoopExecutor', $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $udpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\UdpTransportExecutor', $udpExecutor);
@@ -121,19 +139,25 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('React\Dns\Query\CoopExecutor', $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
@@ -157,19 +181,25 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('React\Dns\Query\CoopExecutor', $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
@@ -194,49 +224,65 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('React\Dns\Query\CoopExecutor', $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $fallbackExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\FallbackExecutor', $fallbackExecutor);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
 
         $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $nameserver = $ref->getValue($tcpExecutor);
 
         $this->assertEquals('tcp://8.8.8.8:53', $nameserver);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'fallback');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
 
         $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $nameserver = $ref->getValue($tcpExecutor);
 
         $this->assertEquals('tcp://1.1.1.1:53', $nameserver);
@@ -262,73 +308,97 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf('React\Dns\Query\CoopExecutor', $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\RetryExecutor', $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $fallbackExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\FallbackExecutor', $fallbackExecutor);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
 
         $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $nameserver = $ref->getValue($tcpExecutor);
 
         $this->assertEquals('tcp://8.8.8.8:53', $nameserver);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'fallback');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $fallbackExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\FallbackExecutor', $fallbackExecutor);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
 
         $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $nameserver = $ref->getValue($tcpExecutor);
 
         $this->assertEquals('tcp://1.1.1.1:53', $nameserver);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'fallback');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TimeoutExecutor', $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf('React\Dns\Query\TcpTransportExecutor', $tcpExecutor);
 
         $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $nameserver = $ref->getValue($tcpExecutor);
 
         $this->assertEquals('tcp://9.9.9.9:53', $nameserver);
@@ -432,7 +502,9 @@ class FactoryTest extends TestCase
         // extract underlying executor that may be wrapped in multiple layers of hosts file executors
         while ($executor instanceof HostsFileExecutor) {
             $reflector = new \ReflectionProperty('React\Dns\Query\HostsFileExecutor', 'fallback');
-            $reflector->setAccessible(true);
+            if (\PHP_VERSION_ID < 80100) {
+                $reflector->setAccessible(true);
+            }
 
             $executor = $reflector->getValue($executor);
         }
@@ -443,14 +515,18 @@ class FactoryTest extends TestCase
     private function getResolverPrivateMemberValue($resolver, $field)
     {
         $reflector = new \ReflectionProperty('React\Dns\Resolver\Resolver', $field);
-        $reflector->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflector->setAccessible(true);
+        }
         return $reflector->getValue($resolver);
     }
 
     private function getCachingExecutorPrivateMemberValue($resolver, $field)
     {
         $reflector = new \ReflectionProperty('React\Dns\Query\CachingExecutor', $field);
-        $reflector->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflector->setAccessible(true);
+        }
         return $reflector->getValue($resolver);
     }
 }


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations