### PR TITLE
[1.x] Increase query count in excessive TCP query tests

### DIFF
--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -336,7 +336,7 @@ class TcpTransportExecutorTest extends TestCase
         $query = new Query('google' . str_repeat('.com', 100), Message::TYPE_A, Message::CLASS_IN);
 
         // send a bunch of queries and keep reference to last promise
-        for ($i = 0; $i < 2000; ++$i) {
+        for ($i = 0; $i < 20000; ++$i) {
             $promise = $executor->query($query);
         }
 
@@ -371,7 +371,7 @@ class TcpTransportExecutorTest extends TestCase
 
         // send a bunch of queries and keep reference to last promise
         $exception = null;
-        for ($i = 0; $i < 2000; ++$i) {
+        for ($i = 0; $i < 20000; ++$i) {
             $promise = $executor->query($query);
             $promise->then(null, function (\Exception $reason) use (&$exception) {
                 $exception = $reason;


### PR DESCRIPTION
This ports #237 from 3.x to 1.x.

In a recent Ubuntu 24.04 runner update something changed that makes PHP code seemingly more performant. In #236 this issue is shown to have something to do with 24.04 because without code changes it works on 22.04. However, that doesn't fix the underlying issue.

While I'm not sure what changed, by increasing these two numbers by 10 folding them we're back at passing tests.