### PR TITLE
[3.x] Improve PHP 8.5+ support by avoiding deprecated `setAccessible()` calls

### DIFF
--- a/src/Query/RetryExecutor.php
+++ b/src/Query/RetryExecutor.php
@@ -49,7 +49,9 @@ final class RetryExecutor implements ExecutorInterface
                 // avoid garbage references by replacing all closures in call stack.
                 // what a lovely piece of code!
                 $r = new \ReflectionProperty(\Exception::class, 'trace');
-                $r->setAccessible(true);
+                if (\PHP_VERSION_ID < 80100) {
+                    $r->setAccessible(true);
+                }
                 $trace = $r->getValue($e);
 
                 // Exception trace arguments are not available on some PHP 7.4 installs

--- a/tests/Query/TcpTransportExecutorTest.php
+++ b/tests/Query/TcpTransportExecutorTest.php
@@ -31,7 +31,9 @@ class TcpTransportExecutorTest extends TestCase
         $executor = new TcpTransportExecutor($input, $loop);
 
         $ref = new \ReflectionProperty($executor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $value = $ref->getValue($executor);
 
         $this->assertEquals($expected, $value);
@@ -70,7 +72,9 @@ class TcpTransportExecutorTest extends TestCase
         $executor = new TcpTransportExecutor('127.0.0.1');
 
         $ref = new \ReflectionProperty($executor, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($executor);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);
@@ -128,7 +132,9 @@ class TcpTransportExecutorTest extends TestCase
         $executor = new TcpTransportExecutor('::1', $loop);
 
         $ref = new \ReflectionProperty($executor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($executor, '///');
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
@@ -307,7 +313,9 @@ class TcpTransportExecutorTest extends TestCase
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
 
         $ref = new \ReflectionProperty($executor, 'writePending');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $writePending = $ref->getValue($executor);
 
         $this->assertTrue($writePending);
@@ -349,7 +357,9 @@ class TcpTransportExecutorTest extends TestCase
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
 
         $ref = new \ReflectionProperty($executor, 'writePending');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $writePending = $ref->getValue($executor);
 
         $this->assertTrue($writePending);
@@ -390,7 +400,9 @@ class TcpTransportExecutorTest extends TestCase
         $executor->handleWritable();
 
         $ref = new \ReflectionProperty($executor, 'writePending');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $writePending = $ref->getValue($executor);
 
         // We expect an EPIPE (Broken pipe) on second write.
@@ -745,7 +757,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);
@@ -780,7 +794,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);
@@ -813,7 +829,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);
@@ -854,7 +872,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);
@@ -892,7 +912,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);
@@ -930,7 +952,9 @@ class TcpTransportExecutorTest extends TestCase
 
         // use outgoing buffer as response message
         $ref = new \ReflectionProperty($executor, 'writeBuffer');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $data = $ref->getValue($executor);
 
         $client = stream_socket_accept($server);

--- a/tests/Query/TimeoutExecutorTest.php
+++ b/tests/Query/TimeoutExecutorTest.php
@@ -38,7 +38,9 @@ class TimeoutExecutorTest extends TestCase
         $executor = new TimeoutExecutor($this->executor, 5.0);
 
         $ref = new \ReflectionProperty($executor, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($executor);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);

--- a/tests/Query/UdpTransportExecutorTest.php
+++ b/tests/Query/UdpTransportExecutorTest.php
@@ -30,7 +30,9 @@ class UdpTransportExecutorTest extends TestCase
         $executor = new UdpTransportExecutor($input, $loop);
 
         $ref = new \ReflectionProperty($executor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $value = $ref->getValue($executor);
 
         $this->assertEquals($expected, $value);
@@ -69,7 +71,9 @@ class UdpTransportExecutorTest extends TestCase
         $executor = new UdpTransportExecutor('127.0.0.1');
 
         $ref = new \ReflectionProperty($executor, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($executor);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);
@@ -132,7 +136,9 @@ class UdpTransportExecutorTest extends TestCase
         $executor = new UdpTransportExecutor('::1', $loop);
 
         $ref = new \ReflectionProperty($executor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($executor, '///');
 
         $query = new Query('google.com', Message::TYPE_A, Message::CLASS_IN);
@@ -161,7 +167,9 @@ class UdpTransportExecutorTest extends TestCase
 
         // increase hard-coded maximum packet size to allow sending excessive data
         $ref = new \ReflectionProperty($executor, 'maxPacketSize');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($executor, PHP_INT_MAX);
 
         $error = null;

--- a/tests/Resolver/FactoryTest.php
+++ b/tests/Resolver/FactoryTest.php
@@ -45,13 +45,17 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(CoopExecutor::class, $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf(RetryExecutor::class, $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $selectiveExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf(SelectiveTransportExecutor::class, $selectiveExecutor);
@@ -59,13 +63,17 @@ class FactoryTest extends TestCase
         // udp below:
 
         $ref = new \ReflectionProperty($selectiveExecutor, 'datagramExecutor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($selectiveExecutor);
 
         $this->assertInstanceOf(TimeoutExecutor::class, $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $udpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf(UdpTransportExecutor::class, $udpExecutor);
@@ -73,13 +81,17 @@ class FactoryTest extends TestCase
         // tcp below:
 
         $ref = new \ReflectionProperty($selectiveExecutor, 'streamExecutor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($selectiveExecutor);
 
         $this->assertInstanceOf(TimeoutExecutor::class, $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf(TcpTransportExecutor::class, $tcpExecutor);
@@ -100,19 +112,25 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(CoopExecutor::class, $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf(RetryExecutor::class, $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf(TimeoutExecutor::class, $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $udpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf(UdpTransportExecutor::class, $udpExecutor);
@@ -133,19 +151,25 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(CoopExecutor::class, $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf(RetryExecutor::class, $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf(TimeoutExecutor::class, $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf(TcpTransportExecutor::class, $tcpExecutor);
@@ -169,19 +193,25 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(CoopExecutor::class, $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf(RetryExecutor::class, $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf(TimeoutExecutor::class, $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf(TcpTransportExecutor::class, $tcpExecutor);
@@ -206,49 +236,65 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(CoopExecutor::class, $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf(RetryExecutor::class, $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $fallbackExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf(FallbackExecutor::class, $fallbackExecutor);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf(TimeoutExecutor::class, $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf(TcpTransportExecutor::class, $tcpExecutor);
 
         $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $nameserver = $ref->getValue($tcpExecutor);
 
         $this->assertEquals('tcp://8.8.8.8:53', $nameserver);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'fallback');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf(TimeoutExecutor::class, $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf(TcpTransportExecutor::class, $tcpExecutor);
 
         $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $nameserver = $ref->getValue($tcpExecutor);
 
         $this->assertEquals('tcp://1.1.1.1:53', $nameserver);
@@ -274,73 +320,97 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(CoopExecutor::class, $coopExecutor);
 
         $ref = new \ReflectionProperty($coopExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $retryExecutor = $ref->getValue($coopExecutor);
 
         $this->assertInstanceOf(RetryExecutor::class, $retryExecutor);
 
         $ref = new \ReflectionProperty($retryExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $fallbackExecutor = $ref->getValue($retryExecutor);
 
         $this->assertInstanceOf(FallbackExecutor::class, $fallbackExecutor);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf(TimeoutExecutor::class, $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf(TcpTransportExecutor::class, $tcpExecutor);
 
         $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $nameserver = $ref->getValue($tcpExecutor);
 
         $this->assertEquals('tcp://8.8.8.8:53', $nameserver);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'fallback');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $fallbackExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf(FallbackExecutor::class, $fallbackExecutor);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf(TimeoutExecutor::class, $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf(TcpTransportExecutor::class, $tcpExecutor);
 
         $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $nameserver = $ref->getValue($tcpExecutor);
 
         $this->assertEquals('tcp://1.1.1.1:53', $nameserver);
 
         $ref = new \ReflectionProperty($fallbackExecutor, 'fallback');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $timeoutExecutor = $ref->getValue($fallbackExecutor);
 
         $this->assertInstanceOf(TimeoutExecutor::class, $timeoutExecutor);
 
         $ref = new \ReflectionProperty($timeoutExecutor, 'executor');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcpExecutor = $ref->getValue($timeoutExecutor);
 
         $this->assertInstanceOf(TcpTransportExecutor::class, $tcpExecutor);
 
         $ref = new \ReflectionProperty($tcpExecutor, 'nameserver');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $nameserver = $ref->getValue($tcpExecutor);
 
         $this->assertEquals('tcp://9.9.9.9:53', $nameserver);
@@ -418,7 +488,9 @@ class FactoryTest extends TestCase
         // extract underlying executor that may be wrapped in multiple layers of hosts file executors
         while ($executor instanceof HostsFileExecutor) {
             $reflector = new \ReflectionProperty(HostsFileExecutor::class, 'fallback');
-            $reflector->setAccessible(true);
+            if (\PHP_VERSION_ID < 80100) {
+                $reflector->setAccessible(true);
+            }
 
             $executor = $reflector->getValue($executor);
         }
@@ -429,14 +501,18 @@ class FactoryTest extends TestCase
     private function getResolverPrivateMemberValue($resolver, $field)
     {
         $reflector = new \ReflectionProperty(Resolver::class, $field);
-        $reflector->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflector->setAccessible(true);
+        }
         return $reflector->getValue($resolver);
     }
 
     private function getCachingExecutorPrivateMemberValue($resolver, $field)
     {
         $reflector = new \ReflectionProperty(CachingExecutor::class, $field);
-        $reflector->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflector->setAccessible(true);
+        }
         return $reflector->getValue($resolver);
     }
 }


### PR DESCRIPTION
This changeset improves PHP 8.5+ support by porting #238 from `1.x` to `3.x` in order to avoid deprecated `setAccessible()` calls. With these changes applied, tests against the current PHP 8.5 RC pass without errors.

Builds on top of #238 (thanks @W0rma), https://github.com/clue/framework-x/pull/282 and #233