### PR TITLE
[3.x] Update to run tests on PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -41,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.5
           coverage: xdebug
           ini-file: development
       - run: composer install


### PR DESCRIPTION
This PR adds running our CI jobs on PHP8.5 and builds up on #233 and #242 to improve PHP8.5+ support by porting #243 from `1.x` to `3.x`.